### PR TITLE
feat(graphql-armor): add stacktraces and batched queries proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,42 @@ const armor = new ApolloArmor({
 
 This section describes how to configure each plugin individually.
 
+### Stacktraces
+
+Stacktraces are managed by the configuration parameter `debug` defaulting to `true` in Apollo. GraphQLArmor changes this default value to `false`.
+
+In order to re-instaure Apollo's default parameter, you can use the following code:
+
+```typescript
+import { ApolloArmor } from '@escape.tech/graphql-armor';
+
+const armor = new ApolloArmor();
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  ...armor.protect(),
+  debug: true // Ignore Armor's recommandations
+});
+```
+
+### Batched queries
+
+Stacktraces are managed by the configuration parameter `debug` defaulting to `true` in Apollo. GraphQLArmor changes this default value to `false`.
+
+In order to re-instaure Apollo's default parameter, you can use the following code:
+
+```typescript
+import { ApolloArmor } from '@escape.tech/graphql-armor';
+
+const armor = new ApolloArmor();
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  ...armor.protect(),
+  allowBatchedHttpRequests: true // Ignore Armor's recommandations
+});
+```
+
 ### Character Limit
 
 `Character Limit plugin` will enforce a character limit on your GraphQL queries.

--- a/packages/graphql-armor/src/index.ts
+++ b/packages/graphql-armor/src/index.ts
@@ -23,6 +23,8 @@ class ApolloArmor {
   protect(): {
     plugins: ApolloServerConfig['plugins'];
     validationRules: ApolloServerConfig['validationRules'];
+    allowBatchedHttpRequests: false;
+    debug: false;
   } {
     let plugins: ApolloServerConfig['plugins'] = [];
     let validationRules: ApolloServerConfig['validationRules'] = [];
@@ -38,6 +40,8 @@ class ApolloArmor {
     return {
       plugins,
       validationRules,
+      allowBatchedHttpRequests: false,
+      debug: false,
     };
   }
 }


### PR DESCRIPTION
This pull request provides support for adding two additional security parameters provided by Apollo: `allowBatchedHttpRequests`for preventing batched queries, and `debug` for removing stacktraces.

With this change,

```
const server = new ApolloServer({
    ...armor.protect()
})
```

will set both `allowBatchedHttpRequests` and `debug` to `false`.

Here is the docs for these two parameters:
- [allowBatchedHttpRequests](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#allowbatchedhttprequests)
- [debug](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#debug)