### PR TITLE
fix: default options in the right place

### DIFF
--- a/packages/graphql-armor/src/apollo/protections/character-limit.ts
+++ b/packages/graphql-armor/src/apollo/protections/character-limit.ts
@@ -1,4 +1,4 @@
-import { CharacterLimitOptions } from '@escape.tech/graphql-armor-character-limit';
+import { CharacterLimitOptions, characterLimitOptionsDefaults } from '@escape.tech/graphql-armor-character-limit';
 import type { GraphQLRequestContext } from 'apollo-server-types';
 import { GraphQLError } from 'graphql';
 
@@ -26,7 +26,8 @@ export class ApolloCharacterLimitProtection extends ApolloProtection {
 
   get options(): CharacterLimitOptions {
     return {
-      maxLength: this.config.characterLimit?.maxLength || 15000,
+      ...characterLimitOptionsDefaults,
+      ...this.config.characterLimit,
     };
   }
 

--- a/packages/graphql-armor/src/apollo/protections/cost-analysis.ts
+++ b/packages/graphql-armor/src/apollo/protections/cost-analysis.ts
@@ -1,6 +1,6 @@
 import { GraphQLError } from 'graphql';
 
-import { CostAnalysisOptions } from '../../config';
+import { CostAnalysisOptions, costAnalysisOptionsDefaults } from '../../config';
 import { costAnalysisRule } from '../../internals/cost-analysis';
 import { ApolloProtection, ApolloServerConfigurationEnhancement } from './base-protection';
 
@@ -13,11 +13,8 @@ export class ApolloCostAnalysisProtection extends ApolloProtection {
 
   get options(): CostAnalysisOptions {
     return {
-      maxCost: this.config.costAnalysis?.maxCost || 5000,
-      objectCost: this.config.costAnalysis?.objectCost || 2,
-      scalarCost: this.config.costAnalysis?.scalarCost || 1,
-      depthCostFactor: this.config.costAnalysis?.depthCostFactor || 1.5,
-      ignoreIntrospection: this.config.costAnalysis?.ignoreIntrospection ?? true,
+      ...costAnalysisOptionsDefaults,
+      ...this.config.costAnalysis,
     };
   }
 

--- a/packages/graphql-armor/src/apollo/protections/max-aliases.ts
+++ b/packages/graphql-armor/src/apollo/protections/max-aliases.ts
@@ -1,4 +1,4 @@
-import { MaxAliasesOptions, maxAliasesRule } from '@escape.tech/graphql-armor-max-aliases';
+import { MaxAliasesOptions, maxAliasesOptionsDefaults, maxAliasesRule } from '@escape.tech/graphql-armor-max-aliases';
 import { GraphQLError } from 'graphql';
 
 import { ApolloProtection, ApolloServerConfigurationEnhancement } from './base-protection';
@@ -12,7 +12,8 @@ export class ApolloMaxAliasesProtection extends ApolloProtection {
 
   get options(): MaxAliasesOptions {
     return {
-      n: this.config.maxAliases?.n || 15,
+      ...maxAliasesOptionsDefaults,
+      ...this.config.maxAliases,
     };
   }
 

--- a/packages/graphql-armor/src/apollo/protections/max-depth.ts
+++ b/packages/graphql-armor/src/apollo/protections/max-depth.ts
@@ -1,4 +1,4 @@
-import { MaxDepthOptions, maxDepthRule } from '@escape.tech/graphql-armor-max-depth';
+import { MaxDepthOptions, maxDepthOptionsDefaults, maxDepthRule } from '@escape.tech/graphql-armor-max-depth';
 import { GraphQLError } from 'graphql';
 
 import { ApolloProtection, ApolloServerConfigurationEnhancement } from './base-protection';
@@ -12,7 +12,8 @@ export class ApolloMaxDepthProtection extends ApolloProtection {
 
   get options(): MaxDepthOptions {
     return {
-      n: this.config.maxDepth?.n || 6,
+      ...maxDepthOptionsDefaults,
+      ...this.config,
     };
   }
 

--- a/packages/graphql-armor/src/apollo/protections/max-directives.ts
+++ b/packages/graphql-armor/src/apollo/protections/max-directives.ts
@@ -1,4 +1,8 @@
-import { MaxDirectivesOptions, maxDirectivesRule } from '@escape.tech/graphql-armor-max-directives';
+import {
+  MaxDirectivesOptions,
+  maxDirectivesOptionsDefaults,
+  maxDirectivesRule,
+} from '@escape.tech/graphql-armor-max-directives';
 import { GraphQLError } from 'graphql';
 
 import { ApolloProtection, ApolloServerConfigurationEnhancement } from './base-protection';
@@ -12,7 +16,8 @@ export class ApolloMaxDirectivesProtection extends ApolloProtection {
 
   get options(): MaxDirectivesOptions {
     return {
-      n: this.config.maxDirectives?.n || 50,
+      ...maxDirectivesOptionsDefaults,
+      ...this.config.maxDirectives,
     };
   }
 

--- a/packages/graphql-armor/src/config.ts
+++ b/packages/graphql-armor/src/config.ts
@@ -16,6 +16,14 @@ export type CostAnalysisOptions = {
   ignoreIntrospection: boolean;
 };
 
+export const costAnalysisOptionsDefaults: CostAnalysisOptions = {
+  maxCost: 5000,
+  objectCost: 2,
+  scalarCost: 1,
+  depthCostFactor: 1.5,
+  ignoreIntrospection: true,
+};
+
 export type GraphQLArmorConfig = {
   blockFieldSuggestion?: ProtectionConfiguration & BlockFieldSuggestionsOptions;
   characterLimit?: ProtectionConfiguration & CharacterLimitOptions;

--- a/packages/graphql-armor/src/envelop/protections/character-limit.ts
+++ b/packages/graphql-armor/src/envelop/protections/character-limit.ts
@@ -1,4 +1,8 @@
-import { CharacterLimitOptions, characterLimitPlugin } from '@escape.tech/graphql-armor-character-limit';
+import {
+  CharacterLimitOptions,
+  characterLimitOptionsDefaults,
+  characterLimitPlugin,
+} from '@escape.tech/graphql-armor-character-limit';
 
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
@@ -11,7 +15,8 @@ export class EnvelopCharacterLimitProtection extends EnvelopProtection {
 
   get options(): CharacterLimitOptions {
     return {
-      maxLength: this.config.characterLimit?.maxLength || 15000,
+      ...characterLimitOptionsDefaults,
+      ...this.config.characterLimit,
     };
   }
 

--- a/packages/graphql-armor/src/envelop/protections/cost-analysis.ts
+++ b/packages/graphql-armor/src/envelop/protections/cost-analysis.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from '@envelop/core';
 import { GraphQLError } from 'graphql';
 
-import { CostAnalysisOptions } from '../../config';
+import { CostAnalysisOptions, costAnalysisOptionsDefaults } from '../../config';
 import { costAnalysisRule } from '../../internals/cost-analysis';
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
@@ -26,11 +26,8 @@ export class EnvelopCostAnalysisProtection extends EnvelopProtection {
 
   get options(): CostAnalysisOptions {
     return {
-      maxCost: this.config.costAnalysis?.maxCost || 5000,
-      objectCost: this.config.costAnalysis?.objectCost || 2,
-      scalarCost: this.config.costAnalysis?.scalarCost || 1,
-      depthCostFactor: this.config.costAnalysis?.depthCostFactor || 1.5,
-      ignoreIntrospection: this.config.costAnalysis?.ignoreIntrospection ?? true,
+      ...costAnalysisOptionsDefaults,
+      ...this.config.costAnalysis,
     };
   }
 

--- a/packages/graphql-armor/src/envelop/protections/max-aliases.ts
+++ b/packages/graphql-armor/src/envelop/protections/max-aliases.ts
@@ -1,4 +1,4 @@
-import { MaxAliasesOptions, maxAliasesPlugin } from '@escape.tech/graphql-armor-max-aliases';
+import { MaxAliasesOptions, maxAliasesOptionsDefaults, maxAliasesPlugin } from '@escape.tech/graphql-armor-max-aliases';
 
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
@@ -11,7 +11,8 @@ export class EnvelopMaxAliasesProtection extends EnvelopProtection {
 
   get options(): MaxAliasesOptions {
     return {
-      n: this.config.maxAliases?.n || 15,
+      ...maxAliasesOptionsDefaults,
+      ...this.config.maxAliases,
     };
   }
 

--- a/packages/graphql-armor/src/envelop/protections/max-depth.ts
+++ b/packages/graphql-armor/src/envelop/protections/max-depth.ts
@@ -1,4 +1,4 @@
-import { MaxDepthOptions, maxDepthPlugin } from '@escape.tech/graphql-armor-max-depth';
+import { MaxDepthOptions, maxDepthOptionsDefaults, maxDepthPlugin } from '@escape.tech/graphql-armor-max-depth';
 
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
@@ -11,7 +11,8 @@ export class EnvelopMaxDepthProtection extends EnvelopProtection {
 
   get options(): MaxDepthOptions {
     return {
-      n: this.config.maxDepth?.n || 6,
+      ...maxDepthOptionsDefaults,
+      ...this.config,
     };
   }
 

--- a/packages/graphql-armor/src/envelop/protections/max-directives.ts
+++ b/packages/graphql-armor/src/envelop/protections/max-directives.ts
@@ -1,4 +1,8 @@
-import { MaxDirectivesOptions, maxDirectivesPlugin } from '@escape.tech/graphql-armor-max-directives';
+import {
+  MaxDirectivesOptions,
+  maxDirectivesOptionsDefaults,
+  maxDirectivesPlugin,
+} from '@escape.tech/graphql-armor-max-directives';
 
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
@@ -11,7 +15,8 @@ export class EnvelopMaxDirectivesProtection extends EnvelopProtection {
 
   get options(): MaxDirectivesOptions {
     return {
-      n: this.config.maxDirectives?.n || 50,
+      ...maxDirectivesOptionsDefaults,
+      ...this.config.maxDirectives,
     };
   }
 

--- a/packages/plugins/character-limit/src/index.ts
+++ b/packages/plugins/character-limit/src/index.ts
@@ -1,8 +1,11 @@
 import type { Plugin } from '@envelop/core';
 import { GraphQLError } from 'graphql';
 
-type CharacterLimitOptions = { maxLength: number };
-const characterLimitPlugin = ({ maxLength }: CharacterLimitOptions): Plugin => {
+export type CharacterLimitOptions = { maxLength: number };
+
+export const characterLimitOptionsDefaults: CharacterLimitOptions = { maxLength: 15000 };
+
+export const characterLimitPlugin = ({ maxLength }: CharacterLimitOptions): Plugin => {
   return {
     onParse({ context }: any) {
       if (context.query.length > maxLength) {
@@ -11,5 +14,3 @@ const characterLimitPlugin = ({ maxLength }: CharacterLimitOptions): Plugin => {
     },
   };
 };
-
-export { characterLimitPlugin, CharacterLimitOptions };

--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -65,4 +65,6 @@ const maxAliasesPlugin = (options: MaxAliasesOptions): Plugin => {
   };
 };
 
+export const maxAliasesOptionsDefaults: MaxAliasesOptions = { n: 15 };
+
 export { maxAliasesRule, maxAliasesPlugin, MaxAliasesOptions };

--- a/packages/plugins/max-depth/src/index.ts
+++ b/packages/plugins/max-depth/src/index.ts
@@ -63,4 +63,6 @@ const maxDepthPlugin = (options: MaxDepthOptions): Plugin => {
   };
 };
 
+export const maxDepthOptionsDefaults: MaxDepthOptions = { n: 6 };
+
 export { maxDepthRule, MaxDepthOptions, maxDepthPlugin };

--- a/packages/plugins/max-directives/src/index.ts
+++ b/packages/plugins/max-directives/src/index.ts
@@ -66,4 +66,6 @@ const maxDirectivesPlugin = (options: MaxDirectivesOptions): Plugin => {
   };
 };
 
+export const maxDirectivesOptionsDefaults: MaxDirectivesOptions = { n: 50 };
+
 export { maxDirectivesRule, MaxDirectivesOptions, maxDirectivesPlugin };


### PR DESCRIPTION
We define default options only once and where the option type is defined. (for each plugin)