### PR TITLE
Configure suggestion mask string

### DIFF
--- a/packages/graphql-armor/src/apollo/protections/block-field-suggestion.ts
+++ b/packages/graphql-armor/src/apollo/protections/block-field-suggestion.ts
@@ -1,18 +1,23 @@
-import type { PluginDefinition } from 'apollo-server-core';
+import {
+  BlockFieldSuggestionsOptions,
+  blockFieldSuggestionsDefaultOptions,
+} from '@escape.tech/graphql-armor-block-field-suggestions';
 import { GraphQLError } from 'graphql';
 
 import { ApolloProtection, ApolloServerConfigurationEnhancement } from './base-protection';
 
-const plugin: PluginDefinition = {
-  async requestDidStart() {
-    return {
-      async didEncounterErrors({ errors }: { errors: ReadonlyArray<GraphQLError> }) {
-        for (const error of errors) {
-          error.message = error.message.replace(/Did you mean ".+"/g, '[Suggestion message hidden by GraphQLArmor]');
-        }
-      },
-    };
-  },
+const plugin = ({ mask }: BlockFieldSuggestionsOptions) => {
+  return {
+    async requestDidStart() {
+      return {
+        async didEncounterErrors({ errors }: { errors: ReadonlyArray<GraphQLError> }) {
+          for (const error of errors) {
+            error.message = error.message.replace(/Did you mean ".+"/g, mask);
+          }
+        },
+      };
+    },
+  };
 };
 
 export class ApolloBlockFieldSuggestionProtection extends ApolloProtection {
@@ -25,7 +30,7 @@ export class ApolloBlockFieldSuggestionProtection extends ApolloProtection {
 
   protect(): ApolloServerConfigurationEnhancement {
     return {
-      plugins: [plugin],
+      plugins: [plugin(this.config.blockFieldSuggestion ?? blockFieldSuggestionsDefaultOptions)],
     };
   }
 }

--- a/packages/graphql-armor/src/config.ts
+++ b/packages/graphql-armor/src/config.ts
@@ -1,3 +1,4 @@
+import type { BlockFieldSuggestionsOptions } from '@escape.tech/graphql-armor-block-field-suggestions';
 import type { CharacterLimitOptions } from '@escape.tech/graphql-armor-character-limit';
 import type { CostLimitOptions } from '@escape.tech/graphql-armor-cost-limit';
 import type { MaxAliasesOptions } from '@escape.tech/graphql-armor-max-aliases';
@@ -9,7 +10,7 @@ export type ProtectionConfiguration = {
 };
 
 export type GraphQLArmorConfig = {
-  blockFieldSuggestion?: ProtectionConfiguration;
+  blockFieldSuggestion?: ProtectionConfiguration & BlockFieldSuggestionsOptions;
   characterLimit?: ProtectionConfiguration & CharacterLimitOptions;
   costLimit?: ProtectionConfiguration & CostLimitOptions;
   maxAliases?: ProtectionConfiguration & MaxAliasesOptions;

--- a/packages/graphql-armor/src/envelop/protections/block-field-suggestion.ts
+++ b/packages/graphql-armor/src/envelop/protections/block-field-suggestion.ts
@@ -12,7 +12,7 @@ export class EnvelopBlockFieldSuggestionProtection extends EnvelopProtection {
 
   protect(): EnvelopConfigurationEnhancement {
     return {
-      plugins: [blockFieldSuggestionsPlugin()],
+      plugins: [blockFieldSuggestionsPlugin(this.config.blockFieldSuggestion)],
     };
   }
 }

--- a/packages/plugins/block-field-suggestions/README.md
+++ b/packages/plugins/block-field-suggestions/README.md
@@ -16,7 +16,7 @@ npm install @escape.tech/graphl-armor-block-field-suggestions
 yarn add @escape.tech/graphl-armor-block-field-suggestions
 ```
 
-## Usage example
+## Usage example default
 
 ### With `@envelop/core` from `@the-guild-org`
 
@@ -28,6 +28,24 @@ const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
     blockFieldSuggestions(),
+  ]
+})
+```
+
+## Usage example with custom mask
+
+### With `@envelop/core` from `@the-guild-org`
+
+```typescript
+import { envelop } from '@envelop/core';
+import { blockFieldSuggestions } from '@escape.tech/graphql-armor-block-field-suggestions';
+
+const getEnveloped = envelop({
+  plugins: [
+    // ... other plugins ...
+    blockFieldSuggestions({
+        mask: '<[REDACTED]>'
+    }),
   ]
 })
 ```

--- a/packages/plugins/block-field-suggestions/src/index.ts
+++ b/packages/plugins/block-field-suggestions/src/index.ts
@@ -1,19 +1,21 @@
 import type { Plugin } from '@envelop/core';
 import { GraphQLError } from 'graphql';
 
-const formatter = (error: GraphQLError): GraphQLError => {
+type BlockFieldSuggestionOptions = { mask?: string };
+
+const formatter = (error: GraphQLError, mask = '[Suggestion message hidden by GraphQLArmor]'): GraphQLError => {
   if (error instanceof GraphQLError) {
-    error.message = error.message.replace(/Did you mean ".+"/g, '[Suggestion message hidden by GraphQLArmor]');
+    error.message = error.message.replace(/Did you mean ".+"/g, mask);
   }
   return error as GraphQLError;
 };
 
-const blockFieldSuggestionsPlugin = (): Plugin => {
+const blockFieldSuggestionsPlugin = (options?: BlockFieldSuggestionOptions): Plugin => {
   return {
     onValidate: () => {
       return function onValidateEnd({ valid, result, setResult }) {
         if (!valid) {
-          setResult(result.map((error) => formatter(error)));
+          setResult(result.map((error) => formatter(error, options?.mask)));
         }
       };
     },

--- a/packages/plugins/block-field-suggestions/src/index.ts
+++ b/packages/plugins/block-field-suggestions/src/index.ts
@@ -1,7 +1,10 @@
 import type { Plugin } from '@envelop/core';
 import { GraphQLError } from 'graphql';
 
-type BlockFieldSuggestionOptions = { mask?: string };
+type BlockFieldSuggestionsOptions = { mask?: string };
+export const blockFieldSuggestionsDefaultOptions: BlockFieldSuggestionsOptions = {
+  mask: '[Suggestion message hidden by GraphQLArmor]',
+};
 
 const formatter = (error: GraphQLError, mask = '[Suggestion message hidden by GraphQLArmor]'): GraphQLError => {
   if (error instanceof GraphQLError) {
@@ -10,7 +13,7 @@ const formatter = (error: GraphQLError, mask = '[Suggestion message hidden by Gr
   return error as GraphQLError;
 };
 
-const blockFieldSuggestionsPlugin = (options?: BlockFieldSuggestionOptions): Plugin => {
+const blockFieldSuggestionsPlugin = (options?: BlockFieldSuggestionsOptions): Plugin => {
   return {
     onValidate: () => {
       return function onValidateEnd({ valid, result, setResult }) {

--- a/packages/plugins/block-field-suggestions/test/index.spec.ts
+++ b/packages/plugins/block-field-suggestions/test/index.spec.ts
@@ -87,4 +87,15 @@ describe('global', () => {
       'Cannot query field "titlee" on type "Book". [Suggestion message hidden by GraphQLArmor]?',
     ]);
   });
+
+  it('should use configured mask', async () => {
+    const testkit = createTestkit([blockFieldSuggestionsPlugin({mask:'<[REDACTED]>'})], schema);
+    const result = await testkit.execute(query);
+
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      'Cannot query field "titlee" on type "Book". <[REDACTED]>?',
+    ]);
+  });
 });

--- a/packages/plugins/block-field-suggestions/test/index.spec.ts
+++ b/packages/plugins/block-field-suggestions/test/index.spec.ts
@@ -89,7 +89,7 @@ describe('global', () => {
   });
 
   it('should use configured mask', async () => {
-    const testkit = createTestkit([blockFieldSuggestionsPlugin({mask:'<[REDACTED]>'})], schema);
+    const testkit = createTestkit([blockFieldSuggestionsPlugin({ mask: '<[REDACTED]>' })], schema);
     const result = await testkit.execute(query);
 
     assertSingleExecutionValue(result);


### PR DESCRIPTION
Adding and optional parameter to the block-field-suggestion plugin to replace the current `[Suggestion message hidden by GraphQLArmor]` in case users would like to obscure their usage of Armor for security. This parameter is also added to the Apollo and Envelop Armor sections. 

https://github.com/Escape-Technologies/graphql-armor/issues/116