### PR TITLE
fix(character-limit): block requests before parsing

### DIFF
--- a/.changeset/honest-trainers-pretend.md
+++ b/.changeset/honest-trainers-pretend.md
@@ -1,0 +1,5 @@
+---
+'@escape.tech/graphql-armor-character-limit': patch
+---
+
+Enforce query character limit before query is parsed

--- a/examples/yoga/test/index.spec.ts
+++ b/examples/yoga/test/index.spec.ts
@@ -38,7 +38,7 @@ describe('startup', () => {
       }`,
       });
 
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode).toBe(400);
     const body = JSON.parse(response.text);
     expect(body.data?.books).toBeUndefined();
     expect(body.errors).toBeDefined();
@@ -54,7 +54,7 @@ describe('startup', () => {
         ...BooksFragment
         ...BooksFragment
       }
-      
+
       fragment BooksFragment on Query {
         books {
           title

--- a/packages/plugins/character-limit/src/index.ts
+++ b/packages/plugins/character-limit/src/index.ts
@@ -1,20 +1,25 @@
 import type { Plugin } from '@envelop/core';
 import { GraphQLError } from 'graphql';
 
-type AfterParseCtx = { query: string | undefined };
 type CharacterLimitOptions = { maxLength?: number };
 const characterLimitDefaultOptions: CharacterLimitOptions = {
   maxLength: 15000,
 };
 
-const characterLimitPlugin = (options?: CharacterLimitOptions): Plugin<AfterParseCtx> => {
+const characterLimitPlugin = (options?: CharacterLimitOptions): Plugin<object> => {
   const maxLength = options?.maxLength ?? characterLimitDefaultOptions.maxLength;
 
   return {
-    onParse({ context }) {
-      if (context.query && context.query.length > maxLength!) {
-        throw new GraphQLError(`Query is too large.`);
-      }
+    onParse({ parseFn, setParseFn }) {
+      setParseFn((source, options) => {
+        const query = typeof source === 'string' ? source : source.body;
+
+        if (query && query.length > maxLength!) {
+          throw new GraphQLError(`Query is too large.`);
+        }
+
+        return parseFn(source, options);
+      });
     },
   };
 };

--- a/packages/plugins/character-limit/test/index.spec.ts
+++ b/packages/plugins/character-limit/test/index.spec.ts
@@ -1,4 +1,3 @@
-import { Plugin } from '@envelop/core';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { describe, expect, it } from '@jest/globals';
@@ -37,16 +36,6 @@ const schema = makeExecutableSchema({
   typeDefs: [typeDefinitions],
 });
 
-const mockedParsePlugin = (): Plugin => {
-  return {
-    onParse({ params, extendContext }) {
-      extendContext({
-        query: params.source,
-      });
-    },
-  };
-};
-
 describe('global', () => {
   it('should be defined', () => {
     expect(characterLimitPlugin).toBeDefined();
@@ -75,7 +64,7 @@ describe('global', () => {
   });
 
   it('should reject query', async () => {
-    const testkit = createTestkit([mockedParsePlugin(), characterLimitPlugin({ maxLength: 54 - 1 })], schema);
+    const testkit = createTestkit([characterLimitPlugin({ maxLength: 54 - 1 })], schema);
     const result = await testkit.execute(query);
 
     assertSingleExecutionValue(result);


### PR DESCRIPTION
Currently the character limit plugin doesn't work in envelop.

The plugin is attempting to read the query from the context object.  This assumption isn't documented, or required.

Updated the plugin to instead replace the parse function and check query length when it attempts to parse the query into a Document.  This has the added benefit of failing during the parse step, allowing yoga to infer that the request was invalid and set the status code to 400.
