### PR TITLE
fix: count field alias in fragment spread

### DIFF
--- a/.changeset/gentle-ants-grin.md
+++ b/.changeset/gentle-ants-grin.md
@@ -1,0 +1,5 @@
+---
+'@escape.tech/graphql-armor-max-aliases': patch
+---
+
+count field alias in fragment spreads

--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -53,6 +53,11 @@ class MaxAliasesVisitor {
       for (let child of node.selectionSet.selections) {
         aliases += this.countAliases(child);
       }
+    } else if (node.kind === 'FragmentSpread') {
+      const fragment = this.context.getFragment(node.name.value);
+      if (fragment) {
+        aliases += this.countAliases(fragment);
+      }
     }
     return aliases;
   }

--- a/packages/plugins/max-aliases/test/index.spec.ts
+++ b/packages/plugins/max-aliases/test/index.spec.ts
@@ -29,7 +29,7 @@ const books = [
 const resolvers = {
   Query: {
     books: () => books,
-    getBook: (title: String) => books.find((book) => book.title === title),
+    getBook: (title: string) => books.find((book) => book.title === title),
   },
 };
 

--- a/packages/plugins/max-aliases/test/index.spec.ts
+++ b/packages/plugins/max-aliases/test/index.spec.ts
@@ -78,4 +78,22 @@ describe('global', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.map((error) => error.message)).toEqual(['Too many aliases.']);
   });
+  it('should respect fragment aliases', async () => {
+    const testkit = createTestkit([maxAliasesPlugin({ n: 1 })], schema);
+    const result = await testkit.execute(/* GraphQL */ `
+      query A {
+        getBook(title: "null") {
+          firstTitle: title
+          ...BookFragment
+        }
+      }
+      fragment BookFragment on Book {
+        secondTitle: title
+      }
+    `);
+
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.map((error) => error.message)).toEqual(['Too many aliases.']);
+  });
 });


### PR DESCRIPTION
Currently, field aliases within fragment spreads are not counted. This PR addresses this.