### PR TITLE
chore(deps)/drop-apollo-server+typesnode

### DIFF
--- a/examples/nestjs/package.json
+++ b/examples/nestjs/package.json
@@ -31,20 +31,18 @@
     "@nestjs/core": "9.0.11",
     "@nestjs/graphql": "10.1.1",
     "@nestjs/platform-express": "9.0.11",
-    "@types/node": "18.6.3",
     "apollo-server-express": "3.10.2",
     "express": "4.18.1",
     "graphql": "^16.5.0",
     "reflect-metadata": "0.1.13",
     "rxjs": "7.5.6",
-    "source-map-support": "0.5.21",
-    "ts-morph": "16.0.0"
+    "source-map-support": "0.5.21"
   },
   "devDependencies": {
     "@nestjs/cli": "9.1.2",
     "@nestjs/testing": "9.0.11",
     "@types/express": "4.17.13",
-    "@types/node": "18.6.3",
+    "@types/node": "^18.6.3",
     "@typescript-eslint/eslint-plugin": "5.36.1",
     "@typescript-eslint/parser": "5.36.1",
     "eslint": "8.23.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
         "@trivago/prettier-plugin-sort-imports": "3.3.0",
         "@types/babel__core": "7.1.19",
         "@types/babel__preset-env": "7.9.2",
-        "@types/node": "18.6.5",
         "@typescript-eslint/eslint-plugin": "5.36.2",
         "@typescript-eslint/parser": "5.36.2",
         "eslint": "8.23.0",

--- a/packages/graphql-armor/package.json
+++ b/packages/graphql-armor/package.json
@@ -42,14 +42,12 @@
   "peerDependencies": {
     "@envelop/core": "^2.4.2",
     "@types/node": "^18.6.3",
-    "apollo-server": "^3.10.0",
     "apollo-server-core": "^3.10.0",
     "apollo-server-types": "^3.6.2",
     "graphql": "^16.5.0"
   },
   "devDependencies": {
     "@envelop/core": "2.6.0",
-    "apollo-server": "3.10.2",
     "apollo-server-core": "3.10.2",
     "apollo-server-types": "3.6.2",
     "ts-node": "10.9.1",

--- a/packages/graphql-armor/package.json
+++ b/packages/graphql-armor/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@envelop/core": "2.6.0",
+    "@types/node": "^18.6.3",
     "apollo-server-core": "3.10.2",
     "apollo-server-types": "3.6.2",
     "ts-node": "10.9.1",

--- a/packages/graphql-armor/package.json
+++ b/packages/graphql-armor/package.json
@@ -41,7 +41,6 @@
   },
   "peerDependencies": {
     "@envelop/core": "^2.4.2",
-    "@types/node": "^18.6.3",
     "apollo-server-core": "^3.10.0",
     "apollo-server-types": "^3.6.2",
     "graphql": "^16.5.0"

--- a/packages/plugins/block-field-suggestions/package.json
+++ b/packages/plugins/block-field-suggestions/package.json
@@ -33,7 +33,6 @@
     "@envelop/core": "2.6.0",
     "@envelop/testing": "4.6.0",
     "@envelop/types": "2.4.0",
-    "@types/node": "18.6.3",
     "typescript": "4.8.2"
   }
 }

--- a/packages/plugins/character-limit/package.json
+++ b/packages/plugins/character-limit/package.json
@@ -33,7 +33,6 @@
     "@envelop/core": "2.6.0",
     "@envelop/testing": "4.6.0",
     "@envelop/types": "2.4.0",
-    "@types/node": "18.6.3",
     "typescript": "4.8.2"
   }
 }

--- a/packages/plugins/cost-limit/package.json
+++ b/packages/plugins/cost-limit/package.json
@@ -33,7 +33,6 @@
     "@envelop/core": "2.6.0",
     "@envelop/testing": "4.6.0",
     "@envelop/types": "2.4.0",
-    "@types/node": "18.6.3",
     "typescript": "4.8.2"
   }
 }

--- a/packages/plugins/document-token-limit/package.json
+++ b/packages/plugins/document-token-limit/package.json
@@ -33,7 +33,6 @@
     "@envelop/core": "2.6.0",
     "@envelop/testing": "4.6.0",
     "@envelop/types": "2.4.0",
-    "@types/node": "18.6.3",
     "typescript": "4.8.2"
   }
 }

--- a/packages/plugins/max-aliases/package.json
+++ b/packages/plugins/max-aliases/package.json
@@ -33,7 +33,6 @@
     "@envelop/core": "2.6.0",
     "@envelop/testing": "4.6.0",
     "@envelop/types": "2.4.0",
-    "@types/node": "18.6.3",
     "typescript": "4.8.2"
   }
 }

--- a/packages/plugins/max-depth/package.json
+++ b/packages/plugins/max-depth/package.json
@@ -33,7 +33,6 @@
     "@envelop/core": "2.6.0",
     "@envelop/testing": "4.6.0",
     "@envelop/types": "2.4.0",
-    "@types/node": "18.6.3",
     "typescript": "4.8.2"
   }
 }

--- a/packages/plugins/max-directives/package.json
+++ b/packages/plugins/max-directives/package.json
@@ -33,7 +33,6 @@
     "@envelop/core": "2.6.0",
     "@envelop/testing": "4.6.0",
     "@envelop/types": "2.4.0",
-    "@types/node": "18.6.3",
     "typescript": "4.8.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,7 +2670,6 @@ __metadata:
     typescript: 4.8.2
   peerDependencies:
     "@envelop/core": ^2.4.2
-    "@types/node": ^18.6.3
     apollo-server-core: ^3.10.0
     apollo-server-types: ^3.6.2
     graphql: ^16.5.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2663,7 +2663,6 @@ __metadata:
     "@escape.tech/graphql-armor-max-aliases": ^1.2.4
     "@escape.tech/graphql-armor-max-depth": ^1.4.4
     "@escape.tech/graphql-armor-max-directives": ^1.2.3
-    apollo-server: 3.10.2
     apollo-server-core: 3.10.2
     apollo-server-types: 3.6.2
     graphql: ^16.5.0
@@ -2672,7 +2671,6 @@ __metadata:
   peerDependencies:
     "@envelop/core": ^2.4.2
     "@types/node": ^18.6.3
-    apollo-server: ^3.10.0
     apollo-server-core: ^3.10.0
     apollo-server-types: ^3.6.2
     graphql: ^16.5.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,7 +2447,6 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    "@types/node": 18.6.3
     graphql: ^16.5.0
     typescript: 4.8.2
   peerDependencies:
@@ -2462,7 +2461,6 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    "@types/node": 18.6.3
     graphql: ^16.5.0
     typescript: 4.8.2
   peerDependencies:
@@ -2477,7 +2475,6 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    "@types/node": 18.6.3
     graphql: ^16.5.0
     typescript: 4.8.2
   peerDependencies:
@@ -2498,7 +2495,6 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    "@types/node": 18.6.3
     graphql: ^16.5.0
     typescript: 4.8.2
   peerDependencies:
@@ -2543,7 +2539,7 @@ __metadata:
     "@nestjs/platform-express": 9.0.11
     "@nestjs/testing": 9.0.11
     "@types/express": 4.17.13
-    "@types/node": 18.6.3
+    "@types/node": ^18.6.3
     "@typescript-eslint/eslint-plugin": 5.36.1
     "@typescript-eslint/parser": 5.36.1
     apollo-server-express: 3.10.2
@@ -2556,7 +2552,6 @@ __metadata:
     reflect-metadata: 0.1.13
     rxjs: 7.5.6
     source-map-support: 0.5.21
-    ts-morph: 16.0.0
     ts-node: 10.9.1
     typescript: 4.8.2
   languageName: unknown
@@ -2585,7 +2580,6 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    "@types/node": 18.6.3
     graphql: ^16.5.0
     typescript: 4.8.2
   peerDependencies:
@@ -2600,7 +2594,6 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    "@types/node": 18.6.3
     graphql: ^16.5.0
     typescript: 4.8.2
   peerDependencies:
@@ -2615,7 +2608,6 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    "@types/node": 18.6.3
     graphql: ^16.5.0
     typescript: 4.8.2
   peerDependencies:
@@ -2641,7 +2633,6 @@ __metadata:
     "@trivago/prettier-plugin-sort-imports": 3.3.0
     "@types/babel__core": 7.1.19
     "@types/babel__preset-env": 7.9.2
-    "@types/node": 18.6.5
     "@typescript-eslint/eslint-plugin": 5.36.2
     "@typescript-eslint/parser": 5.36.2
     eslint: 8.23.0
@@ -2663,6 +2654,7 @@ __metadata:
     "@escape.tech/graphql-armor-max-aliases": ^1.2.4
     "@escape.tech/graphql-armor-max-depth": ^1.4.4
     "@escape.tech/graphql-armor-max-directives": ^1.2.3
+    "@types/node": ^18.6.3
     apollo-server-core: 3.10.2
     apollo-server-types: 3.6.2
     graphql: ^16.5.0
@@ -4194,13 +4186,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.6.5":
-  version: 18.6.5
-  resolution: "@types/node@npm:18.6.5"
-  checksum: e3e66c9a84b94010a57c1b9dac882c08484278d74f9d120dbe6a3e45d00740d178bd1d34a5deee28197c94b9f4359153b637bab9b305328e865027e9987a0f3d
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^10.1.0":
   version: 10.17.60
   resolution: "@types/node@npm:10.17.60"
@@ -4219,6 +4204,13 @@ __metadata:
   version: 14.18.26
   resolution: "@types/node@npm:14.18.26"
   checksum: c6ac3f9d4f6f77c0fa5ac17757779ad4d9835abfe3af5708b7552597cb5c7c1103e83499ccaf767a1cfa70040990bcf3f58761c547051dc8d5077f3c419091b1
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.6.3":
+  version: 18.7.16
+  resolution: "@types/node@npm:18.7.16"
+  checksum: 01a3d35c764a3f0e7370b56e1ad4203731131883c65784e020009014171b3f53c4649cde6c7aa4f1026b907ee87ef6ae6ece2bc518151dc7b81100fe8b1db3ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Drop `apollo-server` from peerDependencies in benefit of `apollo-server-core`/`apollo-server-types`.

Every `apollo-server-*` extension relies on `apollo-server-core`.
`apollo-server` is not used by `apollo-server-koa` for example.


---

Also drop unnecessary `@types/node`