### PR TITLE
chore(deps)/graphql-major-union

### DIFF
--- a/packages/graphql-armor/package.json
+++ b/packages/graphql-armor/package.json
@@ -37,13 +37,13 @@
     "@escape.tech/graphql-armor-max-aliases": "^1.2.4",
     "@escape.tech/graphql-armor-max-depth": "^1.4.4",
     "@escape.tech/graphql-armor-max-directives": "^1.2.3",
-    "graphql": "^16.5.0"
+    "graphql": "^15.8.0 || ^16.0.0"
   },
   "peerDependencies": {
     "@envelop/core": "^2.4.2",
     "apollo-server-core": "^3.10.0",
     "apollo-server-types": "^3.6.2",
-    "graphql": "^16.5.0"
+    "graphql": "^15.8.0 || ^16.0.0"
   },
   "devDependencies": {
     "@envelop/core": "2.6.0",

--- a/packages/plugins/block-field-suggestions/package.json
+++ b/packages/plugins/block-field-suggestions/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
   "dependencies": {
-    "graphql": "^16.5.0"
+    "graphql": "^15.8.0 || ^16.0.0"
   },
   "peerDependencies": {
     "@envelop/core": "^2.4.2"

--- a/packages/plugins/character-limit/package.json
+++ b/packages/plugins/character-limit/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
   "dependencies": {
-    "graphql": "^16.5.0"
+    "graphql": "^15.8.0 || ^16.0.0"
   },
   "peerDependencies": {
     "@envelop/core": "^2.4.2"

--- a/packages/plugins/cost-limit/package.json
+++ b/packages/plugins/cost-limit/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
   "dependencies": {
-    "graphql": "^16.5.0"
+    "graphql": "^15.8.0 || ^16.0.0"
   },
   "peerDependencies": {
     "@envelop/core": "^2.4.2"

--- a/packages/plugins/cost-limit/src/index.ts
+++ b/packages/plugins/cost-limit/src/index.ts
@@ -7,7 +7,7 @@ import type {
   OperationDefinitionNode,
   ValidationContext,
 } from 'graphql';
-import { Kind, GraphQLError } from 'graphql';
+import { GraphQLError, Kind } from 'graphql';
 
 type CostLimitOptions = {
   maxCost?: number;

--- a/packages/plugins/cost-limit/src/index.ts
+++ b/packages/plugins/cost-limit/src/index.ts
@@ -1,14 +1,13 @@
 import type { Plugin } from '@envelop/core';
-import {
+import type {
   FieldNode,
   FragmentDefinitionNode,
   FragmentSpreadNode,
-  GraphQLError,
   InlineFragmentNode,
-  Kind,
   OperationDefinitionNode,
   ValidationContext,
 } from 'graphql';
+import { Kind, GraphQLError } from 'graphql';
 
 type CostLimitOptions = {
   maxCost?: number;

--- a/packages/plugins/document-token-limit/package.json
+++ b/packages/plugins/document-token-limit/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
   "dependencies": {
-    "graphql": "^16.5.0"
+    "graphql": "^15.8.0 || ^16.0.0"
   },
   "peerDependencies": {
     "@envelop/core": "^2.4.2"

--- a/packages/plugins/max-aliases/package.json
+++ b/packages/plugins/max-aliases/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
   "dependencies": {
-    "graphql": "^16.5.0"
+    "graphql": "^15.8.0 || ^16.0.0"
   },
   "peerDependencies": {
     "@envelop/core": "^2.4.2"

--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -1,13 +1,13 @@
 import type { Plugin } from '@envelop/core';
-import {
+import type {
   FieldNode,
   FragmentDefinitionNode,
   FragmentSpreadNode,
-  GraphQLError,
   InlineFragmentNode,
   OperationDefinitionNode,
   ValidationContext,
 } from 'graphql';
+import { GraphQLError } from 'graphql';
 
 type MaxAliasesOptions = { n?: number };
 const maxAliasesDefaultOptions: Required<MaxAliasesOptions> = {

--- a/packages/plugins/max-depth/package.json
+++ b/packages/plugins/max-depth/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
   "dependencies": {
-    "graphql": "^16.5.0"
+    "graphql": "^15.8.0 || ^16.0.0"
   },
   "peerDependencies": {
     "@envelop/core": "^2.4.2"

--- a/packages/plugins/max-depth/src/index.ts
+++ b/packages/plugins/max-depth/src/index.ts
@@ -1,14 +1,13 @@
 import type { Plugin } from '@envelop/core';
-import {
+import type {
   FieldNode,
   FragmentDefinitionNode,
   FragmentSpreadNode,
-  GraphQLError,
   InlineFragmentNode,
-  Kind,
   OperationDefinitionNode,
   ValidationContext,
 } from 'graphql';
+import { GraphQLError, Kind } from 'graphql'
 
 type MaxDepthOptions = { n?: number; ignoreIntrospection?: boolean };
 const maxDepthDefaultOptions: Required<MaxDepthOptions> = {

--- a/packages/plugins/max-depth/src/index.ts
+++ b/packages/plugins/max-depth/src/index.ts
@@ -7,7 +7,7 @@ import type {
   OperationDefinitionNode,
   ValidationContext,
 } from 'graphql';
-import { GraphQLError, Kind } from 'graphql'
+import { GraphQLError, Kind } from 'graphql';
 
 type MaxDepthOptions = { n?: number; ignoreIntrospection?: boolean };
 const maxDepthDefaultOptions: Required<MaxDepthOptions> = {

--- a/packages/plugins/max-directives/package.json
+++ b/packages/plugins/max-directives/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
   "dependencies": {
-    "graphql": "^16.5.0"
+    "graphql": "^15.8.0 || ^16.0.0"
   },
   "peerDependencies": {
     "@envelop/core": "^2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,7 +2447,7 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    graphql: ^16.5.0
+    graphql: ^15.8.0 || ^16.0.0
     typescript: 4.8.2
   peerDependencies:
     "@envelop/core": ^2.4.2
@@ -2461,7 +2461,7 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    graphql: ^16.5.0
+    graphql: ^15.8.0 || ^16.0.0
     typescript: 4.8.2
   peerDependencies:
     "@envelop/core": ^2.4.2
@@ -2475,7 +2475,7 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    graphql: ^16.5.0
+    graphql: ^15.8.0 || ^16.0.0
     typescript: 4.8.2
   peerDependencies:
     "@envelop/core": ^2.4.2
@@ -2495,7 +2495,7 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    graphql: ^16.5.0
+    graphql: ^15.8.0 || ^16.0.0
     typescript: 4.8.2
   peerDependencies:
     "@envelop/core": ^2.4.2
@@ -2580,7 +2580,7 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    graphql: ^16.5.0
+    graphql: ^15.8.0 || ^16.0.0
     typescript: 4.8.2
   peerDependencies:
     "@envelop/core": ^2.4.2
@@ -2594,7 +2594,7 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    graphql: ^16.5.0
+    graphql: ^15.8.0 || ^16.0.0
     typescript: 4.8.2
   peerDependencies:
     "@envelop/core": ^2.4.2
@@ -2608,7 +2608,7 @@ __metadata:
     "@envelop/core": 2.6.0
     "@envelop/testing": 4.6.0
     "@envelop/types": 2.4.0
-    graphql: ^16.5.0
+    graphql: ^15.8.0 || ^16.0.0
     typescript: 4.8.2
   peerDependencies:
     "@envelop/core": ^2.4.2
@@ -2657,14 +2657,14 @@ __metadata:
     "@types/node": ^18.6.3
     apollo-server-core: 3.10.2
     apollo-server-types: 3.6.2
-    graphql: ^16.5.0
+    graphql: ^15.8.0 || ^16.0.0
     ts-node: 10.9.1
     typescript: 4.8.2
   peerDependencies:
     "@envelop/core": ^2.4.2
     apollo-server-core: ^3.10.0
     apollo-server-types: ^3.6.2
-    graphql: ^16.5.0
+    graphql: ^15.8.0 || ^16.0.0
   languageName: unknown
   linkType: soft
 
@@ -7337,10 +7337,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:16.5.0, graphql@npm:^16.5.0":
+"graphql@npm:16.5.0":
   version: 16.5.0
   resolution: "graphql@npm:16.5.0"
   checksum: a82a926d085818934d04fdf303a269af170e79de943678bd2726370a96194f9454ade9d6d76c2de69afbd7b9f0b4f8061619baecbbddbe82125860e675ac219e
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^15.8.0 || ^16.0.0":
+  version: 16.6.0
+  resolution: "graphql@npm:16.6.0"
+  checksum: bf1d9e3c1938ce3c1a81e909bd3ead1ae4707c577f91cff1ca2eca474bfbc7873d5d7b942e1e9777ff5a8304421dba57a4b76d7a29eb19de8711cb70e3c2415e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use union of GraphQL JS major version `^15.8.0 || ^16.0.0`

Lot of people are still using GraphQL JS 15 since apollo is based on it.