### PR TITLE
fix(document-token-limit): reduce default value

### DIFF
--- a/packages/plugins/document-token-limit/src/index.ts
+++ b/packages/plugins/document-token-limit/src/index.ts
@@ -42,7 +42,7 @@ class ParserWithLexer extends Parser {
 
 type DocumentTokenLimitOptions = { maxTokenCount?: number };
 export const documentTokenLimitDefaultOptions: Required<DocumentTokenLimitOptions> = {
-  maxTokenCount: 2000,
+  maxTokenCount: 1000,
 };
 
 export function documentTokenLimitPlugin(options?: DocumentTokenLimitOptions): Plugin {


### PR DESCRIPTION
Time parsing token has been proven quadratic, here 2000 make tests 22 seconds against 7seconds for 1000.
A default value of 1000 tokens should be enough for most usage.