### PR TITLE
chore(examples)/non-branded-names

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@escape.tech/graphql-armor-example-*",
+    "example-*",
     "@escape.tech/graphql-armor-docs"
   ],
   "labels": ["dependencies"],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
         "runtimeExecutable": "yarn",
         "cwd": "${workspaceRoot}",
         "console": "integratedTerminal",
-        "runtimeArgs": ["workspace", "@escape.tech/graphql-armor-example-yoga", "dev"]
+        "runtimeArgs": ["workspace", "example-yoga", "dev"]
     },
     {
         "type": "node",
@@ -29,7 +29,7 @@
         "runtimeExecutable": "yarn",
         "cwd": "${workspaceRoot}",
         "console": "integratedTerminal",
-        "runtimeArgs": ["workspace", "@escape.tech/graphql-armor-example-apollo", "dev"]
+        "runtimeArgs": ["workspace", "example-apollo", "dev"]
     },
     {
         "type": "node",
@@ -38,7 +38,7 @@
         "runtimeExecutable": "yarn",
         "cwd": "${workspaceRoot}",
         "console": "integratedTerminal",
-        "runtimeArgs": ["workspace", "@escape.tech/graphql-armor-example-nestjs", "dev"]
+        "runtimeArgs": ["workspace", "example-nestjs", "dev"]
     },
     {
         "type": "node",

--- a/examples/apollo/README.md
+++ b/examples/apollo/README.md
@@ -3,5 +3,5 @@
 Example using [Apollo](https://www.apollographql.com/docs/apollo-server/)
 
 ```bash
-yarn workspace @escape.tech/graphql-armor-example-apollo {cmd}
+yarn workspace example-apollo {cmd}
 ```

--- a/examples/apollo/package.json
+++ b/examples/apollo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@escape.tech/graphql-armor-example-apollo",
+  "name": "example-apollo",
   "private": true,
   "version": "1.0.0",
   "description": "GraphQL Armor example for Apollo.",

--- a/examples/nestjs/README.md
+++ b/examples/nestjs/README.md
@@ -3,5 +3,5 @@
 Example using [Nest JS](https://nestjs.com/)
 
 ```bash
-yarn workspace @escape.tech/graphql-armor-example-nestjs {cmd}
+yarn workspace example-nestjs {cmd}
 ```

--- a/examples/nestjs/package.json
+++ b/examples/nestjs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@escape.tech/graphql-armor-example-nestjs",
+  "name": "example-nestjs",
   "private": true,
   "version": "1.0.0",
   "description": "GraphQL Armor example for NestJS.",

--- a/examples/yoga/README.md
+++ b/examples/yoga/README.md
@@ -3,5 +3,5 @@
 Example using [Yoga](https://www.graphql-yoga.com/)
 
 ```bash
-yarn workspace @escape.tech/graphql-armor-example-yoga {cmd}
+yarn workspace example-yoga {cmd}
 ```

--- a/examples/yoga/package.json
+++ b/examples/yoga/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@escape.tech/graphql-armor-example-yoga",
+  "name": "example-yoga",
   "private": true,
   "version": "1.0.0",
   "description": "GraphQL Armor example for yoga.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2552,77 +2552,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@escape.tech/graphql-armor-example-apollo@workspace:examples/apollo":
-  version: 0.0.0-use.local
-  resolution: "@escape.tech/graphql-armor-example-apollo@workspace:examples/apollo"
-  dependencies:
-    "@apollo/gateway": 2.1.1
-    "@escape.tech/graphql-armor": "*"
-    "@types/express": 4.17.13
-    "@types/node": 18.6.3
-    apollo-server: 3.10.2
-    apollo-server-express: 3.10.2
-    express: 4.18.1
-    graphql: 16.6.0
-    nodemon: 2.0.19
-    reflect-metadata: 0.1.13
-    rxjs: 7.5.6
-    source-map-support: 0.5.21
-    ts-morph: 16.0.0
-    ts-node: 10.9.1
-    ts-node-dev: 2.0.0
-    typescript: 4.8.2
-  languageName: unknown
-  linkType: soft
-
-"@escape.tech/graphql-armor-example-nestjs@workspace:examples/nestjs":
-  version: 0.0.0-use.local
-  resolution: "@escape.tech/graphql-armor-example-nestjs@workspace:examples/nestjs"
-  dependencies:
-    "@apollo/gateway": 2.1.1
-    "@escape.tech/graphql-armor": "*"
-    "@nestjs/apollo": 10.1.0
-    "@nestjs/cli": 9.1.2
-    "@nestjs/common": 9.0.11
-    "@nestjs/core": 9.0.11
-    "@nestjs/graphql": 10.1.1
-    "@nestjs/platform-express": 9.0.11
-    "@nestjs/testing": 9.0.11
-    "@types/express": 4.17.13
-    "@types/node": 18.7.16
-    "@typescript-eslint/eslint-plugin": 5.36.2
-    "@typescript-eslint/parser": 5.36.2
-    apollo-server-express: 3.10.2
-    eslint: 8.23.0
-    eslint-config-google: 0.14.0
-    express: 4.18.1
-    graphql: 16.6.0
-    nodemon: 2.0.19
-    prettier: 2.7.1
-    reflect-metadata: 0.1.13
-    rxjs: 7.5.6
-    source-map-support: 0.5.21
-    ts-node: 10.9.1
-    typescript: 4.8.2
-  languageName: unknown
-  linkType: soft
-
-"@escape.tech/graphql-armor-example-yoga@workspace:examples/yoga":
-  version: 0.0.0-use.local
-  resolution: "@escape.tech/graphql-armor-example-yoga@workspace:examples/yoga"
-  dependencies:
-    "@escape.tech/graphql-armor": "*"
-    "@graphql-tools/schema": 9.0.3
-    "@graphql-yoga/node": 2.13.13
-    "@types/node": 18.6.3
-    graphql: 16.6.0
-    supertest: 6.2.4
-    ts-node: 10.9.1
-    ts-node-dev: 2.0.0
-    typescript: 4.8.2
-  languageName: unknown
-  linkType: soft
-
 "@escape.tech/graphql-armor-max-aliases@^1.3.1, @escape.tech/graphql-armor-max-aliases@workspace:packages/plugins/max-aliases":
   version: 0.0.0-use.local
   resolution: "@escape.tech/graphql-armor-max-aliases@workspace:packages/plugins/max-aliases"
@@ -6879,6 +6808,77 @@ __metadata:
   checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
   languageName: node
   linkType: hard
+
+"example-apollo@workspace:examples/apollo":
+  version: 0.0.0-use.local
+  resolution: "example-apollo@workspace:examples/apollo"
+  dependencies:
+    "@apollo/gateway": 2.1.1
+    "@escape.tech/graphql-armor": "*"
+    "@types/express": 4.17.13
+    "@types/node": 18.6.3
+    apollo-server: 3.10.2
+    apollo-server-express: 3.10.2
+    express: 4.18.1
+    graphql: 16.6.0
+    nodemon: 2.0.19
+    reflect-metadata: 0.1.13
+    rxjs: 7.5.6
+    source-map-support: 0.5.21
+    ts-morph: 16.0.0
+    ts-node: 10.9.1
+    ts-node-dev: 2.0.0
+    typescript: 4.8.2
+  languageName: unknown
+  linkType: soft
+
+"example-nestjs@workspace:examples/nestjs":
+  version: 0.0.0-use.local
+  resolution: "example-nestjs@workspace:examples/nestjs"
+  dependencies:
+    "@apollo/gateway": 2.1.1
+    "@escape.tech/graphql-armor": "*"
+    "@nestjs/apollo": 10.1.0
+    "@nestjs/cli": 9.1.2
+    "@nestjs/common": 9.0.11
+    "@nestjs/core": 9.0.11
+    "@nestjs/graphql": 10.1.1
+    "@nestjs/platform-express": 9.0.11
+    "@nestjs/testing": 9.0.11
+    "@types/express": 4.17.13
+    "@types/node": 18.7.16
+    "@typescript-eslint/eslint-plugin": 5.36.2
+    "@typescript-eslint/parser": 5.36.2
+    apollo-server-express: 3.10.2
+    eslint: 8.23.0
+    eslint-config-google: 0.14.0
+    express: 4.18.1
+    graphql: 16.6.0
+    nodemon: 2.0.19
+    prettier: 2.7.1
+    reflect-metadata: 0.1.13
+    rxjs: 7.5.6
+    source-map-support: 0.5.21
+    ts-node: 10.9.1
+    typescript: 4.8.2
+  languageName: unknown
+  linkType: soft
+
+"example-yoga@workspace:examples/yoga":
+  version: 0.0.0-use.local
+  resolution: "example-yoga@workspace:examples/yoga"
+  dependencies:
+    "@escape.tech/graphql-armor": "*"
+    "@graphql-tools/schema": 9.0.3
+    "@graphql-yoga/node": 2.13.13
+    "@types/node": 18.6.3
+    graphql: 16.6.0
+    supertest: 6.2.4
+    ts-node: 10.9.1
+    ts-node-dev: 2.0.0
+    typescript: 4.8.2
+  languageName: unknown
+  linkType: soft
 
 "execa@npm:^4.0.2":
   version: 4.1.0


### PR DESCRIPTION
- Remove branding from examples

This will make examples easier to access using CLI.
This was not sustainable as we don't publish theses packages anyway.