### PR TITLE
chore: fixed install-dev.sh

### DIFF
--- a/install-dev.sh
+++ b/install-dev.sh
@@ -4,9 +4,9 @@ echo "Installing development tools..."
 yarn
 
 echo "Initializing mookme..."
-yarn dlx mookme init --only-hook --skip-types-selection
+yarn dlx @escape.tech/mookme init --only-hook --skip-types-selection
 
-echo "Building GraphQL Armor"
-yarn workspaces foreach -ptv run build
+echo "Building GraphQL Armor..."
+yarn build
 
-echo "Run commands using `yarn workspace @escape.tech/{pkg} {cmd}`"
+echo "Run commands using 'yarn workspace @escape.tech/{pkg} {cmd}'"

--- a/packages/plugins/max-tokens/src/index.ts
+++ b/packages/plugins/max-tokens/src/index.ts
@@ -73,6 +73,7 @@ export class MaxTokensParserWLexer extends Parser {
 
 export function maxTokensPlugin(config?: MaxTokensOptions): Plugin {
   function parseWithTokenLimit(source: string | Source, options?: ParseOptions) {
+    // @ts-expect-error TODO(@c3b5aw): address the type issue
     const parser = new MaxTokensParserWLexer(source, Object.assign({}, options, config));
     return parser.parseDocument();
   }


### PR DESCRIPTION
Running install-dev.sh is quite a ride!

<details>
<summary>Logs</summary>

```console
Installing development tools...
➤ YN0000: ┌ Resolution step
➤ YN0002: │ @docsearch/react@npm:3.2.1 [9c7a7] doesn't provide @algolia/client-search (p9aa09), requested by @algolia/autocomplete-preset-algolia
➤ YN0002: │ ts-node-dev@npm:2.0.0 [a7c7e] doesn't provide @types/node (p5d27c), requested by ts-node
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 0s 254ms
➤ YN0000: ┌ Fetch step
➤ YN0013: │ yargs@npm:15.4.1 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yargs@npm:17.5.1 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yn@npm:3.1.1 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yocto-queue@npm:0.1.0 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ zwitch@npm:1.0.5 can't be found in the cache and will be fetched from the remote registry
➤ YN0000: └ Completed in 43s 533ms
➤ YN0000: ┌ Link step
➤ YN0007: │ @nestjs/core@npm:9.1.4 [6f8a8] must be built because it never has been before or the last one failed
➤ YN0007: │ @apollo/protobufjs@npm:1.2.6 must be built because it never has been before or the last one failed
➤ YN0007: │ core-js@npm:3.25.5 must be built because it never has been before or the last one failed
➤ YN0007: │ @apollo/protobufjs@npm:1.2.4 must be built because it never has been before or the last one failed
➤ YN0007: │ core-js-pure@npm:3.25.5 must be built because it never has been before or the last one failed
➤ YN0000: └ Completed in 13s 665ms
➤ YN0000: Done with warnings in 57s 726ms
Initializing mookme...
➤ YN0027: mookme@unknown can't be resolved to a satisfying range
➤ YN0035: The remote server failed to provide the requested resource
➤ YN0035:   Response Code: 404 (Not Found)
➤ YN0035:   Request Method: GET
➤ YN0035:   Request URL: https://registry.yarnpkg.com/mookme

➤ Errors happened when preparing the environment required to run this command.
Building GraphQL Armor
➤ YN0000: [@escape.tech/graphql-armor-monorepo]: Process started
➤ YN0000: [@escape.tech/graphql-armor-block-field-suggestions]: Process started
➤ YN0000: [@escape.tech/graphql-armor-types]: Process started
➤ YN0000: [docs]: Process started
➤ YN0000: [@escape.tech/graphql-armor-types]: Process exited (exit code 0), completed in 3s 239ms
➤ YN0000: [@escape.tech/graphql-armor-block-field-suggestions]: Process exited (exit code 0), completed in 3s 307ms
➤ YN0000: [@escape.tech/graphql-armor-monorepo]: 🎁 info building bundles!
➤ YN0000: [@escape.tech/graphql-armor-monorepo]: 🎁 success built bundles!
➤ YN0000: [@escape.tech/graphql-armor-monorepo]: Process exited (exit code 0), completed in 11s 12ms
➤ YN0000: [docs]: [INFO] [en] Creating an optimized production build...
➤ YN0000: [docs]: ℹ Compiling Client
➤ YN0000: [docs]: ℹ Compiling Server
➤ YN0000: [docs]: ✔ Client: Compiled successfully in 13.24s
➤ YN0000: [docs]: ✔ Server: Compiled successfully in 15.18s
➤ YN0000: [docs]: [SUCCESS] Generated static files in "build".
➤ YN0000: [docs]: [INFO] Use `npm run serve` command to test your build locally.
➤ YN0000: [docs]: Process exited (exit code 0), completed in 33s 365ms
➤ YN0000: [@escape.tech/graphql-armor-character-limit]: Process started
➤ YN0000: [@escape.tech/graphql-armor-cost-limit]: Process started
➤ YN0000: [@escape.tech/graphql-armor-max-aliases]: Process started
➤ YN0000: [@escape.tech/graphql-armor-max-depth]: Process started
➤ YN0000: [@escape.tech/graphql-armor-max-directives]: Process started
➤ YN0000: [@escape.tech/graphql-armor-max-tokens]: Process started
➤ YN0000: [@escape.tech/graphql-armor-character-limit]: Process exited (exit code 0), completed in 3s 276ms
➤ YN0000: [@escape.tech/graphql-armor-max-directives]: Process exited (exit code 0), completed in 3s 326ms
➤ YN0000: [@escape.tech/graphql-armor-max-tokens]: src/index.ts(76,54): error TS2345: Argument of type 'ParseOptions & { n?: number | undefined; } & GraphQLArmorCallbackConfiguration' is not assignable to parameter of type 'maxTokensParserWLexerOptions | undefined'.
➤ YN0000: [@escape.tech/graphql-armor-max-tokens]:   Type 'ParseOptions & { n?: number | undefined; } & GraphQLArmorCallbackConfiguration' is not assignable to type 'maxTokensParserWLexerOptions'.
➤ YN0000: [@escape.tech/graphql-armor-max-tokens]:     Type 'ParseOptions & { n?: number | undefined; } & GraphQLArmorCallbackConfiguration' is not assignable to type '{ n: number; }'.
➤ YN0000: [@escape.tech/graphql-armor-max-tokens]:       Types of property 'n' are incompatible.
➤ YN0000: [@escape.tech/graphql-armor-max-tokens]:         Type 'number | undefined' is not assignable to type 'number'.
➤ YN0000: [@escape.tech/graphql-armor-max-tokens]:           Type 'undefined' is not assignable to type 'number'.
➤ YN0000: [@escape.tech/graphql-armor-max-tokens]: Process exited (exit code 2), completed in 3s 336ms
➤ YN0000: [@escape.tech/graphql-armor-cost-limit]: Process exited (exit code 0), completed in 3s 370ms
➤ YN0000: [@escape.tech/graphql-armor-max-aliases]: Process exited (exit code 0), completed in 3s 370ms
➤ YN0000: [@escape.tech/graphql-armor-max-depth]: Process exited (exit code 0), completed in 3s 376ms
➤ YN0000: The command failed for workspaces that are depended upon by other workspaces; can't satisfy the dependency graph
➤ YN0000: Failed with errors in 36s 819ms
Run commands using Usage Error: Workspace '@escape.tech/{pkg}' not found. Did you mean any of the following:
  - @escape.tech/graphql-armor
  - @escape.tech/graphql-armor-block-field-suggestions
  - @escape.tech/graphql-armor-character-limit
  - @escape.tech/graphql-armor-cost-limit
  - @escape.tech/graphql-armor-max-aliases
  - @escape.tech/graphql-armor-max-depth
  - @escape.tech/graphql-armor-max-directives
  - @escape.tech/graphql-armor-max-tokens
  - @escape.tech/graphql-armor-monorepo
  - @escape.tech/graphql-armor-types
  - docs
  - example-apollo
  - example-nestjs
  - example-yoga?

$ yarn workspace <workspaceName> <commandName> ...
```

</details>

<details>
<summary>Files created</summary>

<img width="261" alt="image" src="https://user-images.githubusercontent.com/48261497/197714602-c3b13892-fcaf-44bc-99e5-1e7d8a0cf82d.png">

</details>

This PR address some of these issues