### PR TITLE
docs(plugins): correct cost limit option

### DIFF
--- a/services/docs/docs/plugins/cost-limit.md
+++ b/services/docs/docs/plugins/cost-limit.md
@@ -12,7 +12,7 @@
 
 ```ts
 GraphQLArmor({
-  maxAliases: {
+  costLimit: {
     // Toogle the plugin | default: true
     enabled?: boolean,
     


### PR DESCRIPTION
This PR corrects the Cost Limit Plugin docs where the config option incorrectly referenced `maxAliases` instead of `costLimit`.