### PR TITLE
fix(cost-limit): skip operation definition cost

### DIFF
--- a/.changeset/famous-trees-wait.md
+++ b/.changeset/famous-trees-wait.md
@@ -1,0 +1,5 @@
+---
+'@escape.tech/graphql-armor-cost-limit': minor
+---
+
+Remove OperationDefinition from calculation

--- a/examples/apollo/test/index.spec.ts
+++ b/examples/apollo/test/index.spec.ts
@@ -43,6 +43,9 @@ describe('startup', () => {
         ...BooksFragment
         ...BooksFragment
         ...BooksFragment
+        ...BooksFragment
+        ...BooksFragment
+        ...BooksFragment
       }
       
       fragment BooksFragment on Query {
@@ -53,7 +56,7 @@ describe('startup', () => {
       }`,
     });
     expect(query.errors).toBeDefined();
-    expect(query.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 139.');
+    expect(query.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 138.');
   });
 
   it('should block field suggestion', async () => {

--- a/examples/yoga/test/index.spec.ts
+++ b/examples/yoga/test/index.spec.ts
@@ -51,6 +51,9 @@ describe('startup', () => {
         ...BooksFragment
         ...BooksFragment
         ...BooksFragment
+        ...BooksFragment
+        ...BooksFragment
+        ...BooksFragment
       }
 
       fragment BooksFragment on Query {
@@ -65,7 +68,7 @@ describe('startup', () => {
     const body = JSON.parse(response.text);
     expect(body.data?.books).toBeUndefined();
     expect(body.errors).toBeDefined();
-    expect(body.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 139.');
+    expect(body.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 138.');
   });
 
   it('should disable field suggestion', async () => {

--- a/packages/plugins/cost-limit/test/index.spec.ts
+++ b/packages/plugins/cost-limit/test/index.spec.ts
@@ -69,8 +69,8 @@ describe('global', () => {
       [
         costLimitPlugin({
           maxCost: 10,
-          objectCost: 1,
-          scalarCost: 1,
+          objectCost: 4,
+          scalarCost: 2,
           depthCostFactor: 2,
           ignoreIntrospection: true,
         }),
@@ -82,7 +82,7 @@ describe('global', () => {
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
     expect(result.errors?.map((error) => error.message)).toEqual([
-      'Syntax Error: Query Cost limit of 10 exceeded, found 11.',
+      'Syntax Error: Query Cost limit of 10 exceeded, found 12.',
     ]);
   });
 
@@ -107,13 +107,13 @@ describe('global', () => {
   });
 
   it('should support fragment', async () => {
-    const maxCost = 46;
+    const maxCost = 57;
     const testkit = createTestkit(
       [
         costLimitPlugin({
           maxCost: maxCost,
-          objectCost: 1,
-          scalarCost: 1,
+          objectCost: 4,
+          scalarCost: 2,
           depthCostFactor: 2,
           ignoreIntrospection: true,
         }),


### PR DESCRIPTION
Cost limit plugin include `OperationDefinition` token in the calculation.
This is totally legitimate but leading to inconsistency while calculating the cost by hand.

This change won't affect fragments.
The global cost is lowered by a depth factor.