### PR TITLE
chore: upgrades graphql-armor-cost-limit plugin to 1.7.0

### DIFF
--- a/.changeset/beige-rockets-wonder.md
+++ b/.changeset/beige-rockets-wonder.md
@@ -1,0 +1,5 @@
+---
+'@escape.tech/graphql-armor': minor
+---
+
+updates cost-limit plugin to 1.7.0

--- a/packages/graphql-armor/README.md
+++ b/packages/graphql-armor/README.md
@@ -33,7 +33,7 @@ We support the following engines :
 - [Apollo Server](https://www.apollographql.com/)
 - [GraphQL Yoga](https://www.graphql-yoga.com/)
 
-We additionnaly support the following engines through the [Envelop](https://www.envelop.dev/) plugin system :
+We additionally support the following engines through the [Envelop](https://www.envelop.dev/) plugin system :
 
 - GraphQL-Helix
 - Node.js HTTP
@@ -167,7 +167,7 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   ...armor.protect(),
-  debug: true // Ignore Armor's recommandation
+  debug: true // Ignore Armor's recommendation
 });
 ```
 
@@ -187,7 +187,7 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   ...armor.protect(),
-  allowBatchedHttpRequests: true // Ignore Armor's recommandations
+  allowBatchedHttpRequests: true // Ignore Armor's recommendations
 });
 ```
 


### PR DESCRIPTION
When the `graphql-armor-cost-limit` was updated, the main `graphql-armor` package didn't seem to publish:

```
16
🦋  info npm info @escape.tech/graphql-armor
17
🦋  info npm info @escape.tech/graphql-armor-block-field-suggestions
18
🦋  info npm info @escape.tech/graphql-armor-character-limit
19
🦋  info npm info @escape.tech/graphql-armor-cost-limit
20
🦋  info npm info @escape.tech/graphql-armor-max-aliases
21
🦋  info npm info @escape.tech/graphql-armor-max-depth
22
🦋  info npm info @escape.tech/graphql-armor-max-directives
23
🦋  info npm info @escape.tech/graphql-armor-max-tokens
24
🦋  info npm info @escape.tech/graphql-armor-types
25
🦋  warn @escape.tech/graphql-armor is not being published because version 1.6.0 is already published on npm
```

This PR does two things:

1 - has some minor doc typo corrections (maybe should have been a separate PR)
2 - bumps graphql-armor so a new version can be published with the latest cost-limit plugin

 The changes has a minor bump (to 1.6.1?) but perhaps this should be a major to 1.7.0?