### PR TITLE
fix: graceful recursive fragments

### DIFF
--- a/.changeset/tough-weeks-yawn.md
+++ b/.changeset/tough-weeks-yawn.md
@@ -1,0 +1,5 @@
+---
+'@escape.tech/graphql-armor-max-aliases': minor
+---
+
+add fragmentRecursionCost

--- a/.changeset/wicked-shrimps-arrive.md
+++ b/.changeset/wicked-shrimps-arrive.md
@@ -1,0 +1,7 @@
+---
+'@escape.tech/graphql-armor-max-aliases': patch
+'@escape.tech/graphql-armor-cost-limit': patch
+'@escape.tech/graphql-armor-max-depth': patch
+---
+
+graceful handler for recursive fragments

--- a/examples/apollo/test/index.spec.ts
+++ b/examples/apollo/test/index.spec.ts
@@ -56,7 +56,9 @@ describe('startup', () => {
       }`,
     });
     expect(query.errors).toBeDefined();
-    expect(query.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 138.');
+    expect(query.errors?.map((e) => e.message)).toContain(
+      'Syntax Error: Query Cost limit of 100 exceeded, found 5023.',
+    );
   });
 
   it('should block field suggestion', async () => {

--- a/examples/yoga/test/index.spec.ts
+++ b/examples/yoga/test/index.spec.ts
@@ -68,7 +68,7 @@ describe('startup', () => {
     const body = JSON.parse(response.text);
     expect(body.data?.books).toBeUndefined();
     expect(body.errors).toBeDefined();
-    expect(body.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 138.');
+    expect(body.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 5023.');
   });
 
   it('should disable field suggestion', async () => {

--- a/packages/plugins/cost-limit/src/index.ts
+++ b/packages/plugins/cost-limit/src/index.ts
@@ -17,12 +17,14 @@ export type CostLimitOptions = {
   scalarCost?: number;
   depthCostFactor?: number;
   ignoreIntrospection?: boolean;
+  fragmentRecursionCost?: number;
 } & GraphQLArmorCallbackConfiguration;
 const costLimitDefaultOptions: Required<CostLimitOptions> = {
   maxCost: 5000,
   objectCost: 2,
   scalarCost: 1,
   depthCostFactor: 1.5,
+  fragmentRecursionCost: 1000,
   ignoreIntrospection: true,
   onAccept: [],
   onReject: [],
@@ -95,7 +97,7 @@ class CostLimitVisitor {
 
     if (node.kind == Kind.FRAGMENT_SPREAD) {
       if (this.visitedFragments.has(node.name.value)) {
-        return 0;
+        return this.config.fragmentRecursionCost;
       }
       this.visitedFragments.add(node.name.value);
       const fragment = this.context.getFragment(node.name.value);

--- a/packages/plugins/cost-limit/src/index.ts
+++ b/packages/plugins/cost-limit/src/index.ts
@@ -34,6 +34,7 @@ class CostLimitVisitor {
 
   private readonly context: ValidationContext;
   private readonly config: Required<CostLimitOptions>;
+  private readonly visitedFragments: Set<string> = new Set();
 
   constructor(context: ValidationContext, options?: CostLimitOptions) {
     this.context = context;
@@ -93,6 +94,10 @@ class CostLimitVisitor {
     }
 
     if (node.kind == Kind.FRAGMENT_SPREAD) {
+      if (this.visitedFragments.has(node.name.value)) {
+        return 0;
+      }
+      this.visitedFragments.add(node.name.value);
       const fragment = this.context.getFragment(node.name.value);
       if (fragment) {
         cost += this.config.depthCostFactor * this.computeComplexity(fragment, depth + 1);

--- a/packages/plugins/cost-limit/test/index.spec.ts
+++ b/packages/plugins/cost-limit/test/index.spec.ts
@@ -139,4 +139,29 @@ describe('global', () => {
       `Syntax Error: Query Cost limit of ${maxCost} exceeded, found ${maxCost + 1}.`,
     ]);
   });
+
+  it('should not crash on recursive fragment', async () => {
+    const testkit = createTestkit([costLimitPlugin({
+      maxCost: 50,
+      objectCost: 4,
+      scalarCost: 2,
+      depthCostFactor: 2,
+      ignoreIntrospection: true,
+    })], schema);
+    const result = await testkit.execute(`query {
+        ...A
+      }
+
+      fragment A on Query {
+        ...B
+      }
+
+      fragment B on Query {
+        ...A
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.map((error) => error.message)).toContain('Cannot spread fragment "A" within itself via "B".');
+  });
 });

--- a/packages/plugins/cost-limit/test/index.spec.ts
+++ b/packages/plugins/cost-limit/test/index.spec.ts
@@ -141,13 +141,18 @@ describe('global', () => {
   });
 
   it('should not crash on recursive fragment', async () => {
-    const testkit = createTestkit([costLimitPlugin({
-      maxCost: 50,
-      objectCost: 4,
-      scalarCost: 2,
-      depthCostFactor: 2,
-      ignoreIntrospection: true,
-    })], schema);
+    const testkit = createTestkit(
+      [
+        costLimitPlugin({
+          maxCost: 50,
+          objectCost: 4,
+          scalarCost: 2,
+          depthCostFactor: 2,
+          ignoreIntrospection: true,
+        }),
+      ],
+      schema,
+    );
     const result = await testkit.execute(`query {
         ...A
       }

--- a/packages/plugins/cost-limit/test/index.spec.ts
+++ b/packages/plugins/cost-limit/test/index.spec.ts
@@ -167,6 +167,8 @@ describe('global', () => {
     `);
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
-    expect(result.errors?.map((error) => error.message)).toContain('Cannot spread fragment "A" within itself via "B".');
+    expect(result.errors?.map((error) => error.message)).toContain(
+      'Syntax Error: Query Cost limit of 50 exceeded, found 16050.',
+    );
   });
 });

--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -6,9 +6,9 @@ import {
   FragmentSpreadNode,
   GraphQLError,
   InlineFragmentNode,
+  Kind,
   OperationDefinitionNode,
   ValidationContext,
-  Kind,
 } from 'graphql';
 
 type MaxAliasesOptions = { n?: number } & GraphQLArmorCallbackConfiguration;

--- a/packages/plugins/max-aliases/test/index.spec.ts
+++ b/packages/plugins/max-aliases/test/index.spec.ts
@@ -103,4 +103,23 @@ describe('global', () => {
       `Syntax Error: Aliases limit of ${maxAliases} exceeded, found ${maxAliases + 1}.`,
     ]);
   });
+
+  it('should not crash on recursive fragment', async () => {
+    const testkit = createTestkit([maxAliasesPlugin({ n: 3 })], schema);
+    const result = await testkit.execute(`query {
+        ...A
+      }
+
+      fragment A on Query {
+        ...B
+      }
+
+      fragment B on Query {
+        ...A
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.map((error) => error.message)).toContain('Cannot spread fragment "A" within itself via "B".');
+  });
 });

--- a/packages/plugins/max-depth/test/index.spec.ts
+++ b/packages/plugins/max-depth/test/index.spec.ts
@@ -119,4 +119,23 @@ describe('global', () => {
     expect(result.errors).toBeUndefined();
     expect(result.data?.__schema).toBeDefined();
   });
+
+  it('should not crash on recursive fragment', async () => {
+    const testkit = createTestkit([maxDepthPlugin({ n: 3 })], schema);
+    const result = await testkit.execute(`query {
+        ...A
+      }
+
+      fragment A on Query {
+        ...B
+      }
+
+      fragment B on Query {
+        ...A
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.map((error) => error.message)).toContain('Cannot spread fragment "A" within itself via "B".');
+  });
 });

--- a/packages/plugins/max-depth/test/index.spec.ts
+++ b/packages/plugins/max-depth/test/index.spec.ts
@@ -136,6 +136,8 @@ describe('global', () => {
     `);
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
-    expect(result.errors?.map((error) => error.message)).toContain('Cannot spread fragment "A" within itself via "B".');
+    expect(result.errors?.map((error) => error.message)).toContain(
+      'Syntax Error: Query depth limit of 3 exceeded, found 4.',
+    );
   });
 });


### PR DESCRIPTION
This MR handle the recursive fragment problem gracefully and prevent `max recursion error` to be thrown.
This affect:

- cost-limit
- max-directives
- max-aliases