### PR TITLE
fix: inline fragments visitor

### DIFF
--- a/.changeset/six-readers-juggle.md
+++ b/.changeset/six-readers-juggle.md
@@ -1,0 +1,9 @@
+---
+'@escape.tech/graphql-armor-max-directives': patch
+'@escape.tech/graphql-armor-max-aliases': patch
+'@escape.tech/graphql-armor-cost-limit': patch
+'@escape.tech/graphql-armor-max-depth': patch
+'@escape.tech/graphql-armor': patch
+---
+
+Fix: Inline fragment visitor (Thanks @simoncrypta @dthyresson)

--- a/examples/apollo-v3/test/index.spec.ts
+++ b/examples/apollo-v3/test/index.spec.ts
@@ -56,7 +56,7 @@ describe('startup', () => {
     });
     expect(query.errors).toBeDefined();
     expect(query.errors?.map((e) => e.message)).toContain(
-      'Syntax Error: Query Cost limit of 100 exceeded, found 5023.',
+      'Syntax Error: Query Cost limit of 100 exceeded, found 138.',
     );
   });
 

--- a/examples/apollo-v3/test/index.spec.ts
+++ b/examples/apollo-v3/test/index.spec.ts
@@ -55,9 +55,7 @@ describe('startup', () => {
       }`,
     });
     expect(query.errors).toBeDefined();
-    expect(query.errors?.map((e) => e.message)).toContain(
-      'Syntax Error: Query Cost limit of 100 exceeded, found 138.',
-    );
+    expect(query.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 138.');
   });
 
   it('should block field suggestion', async () => {

--- a/examples/apollo/test/index.spec.ts
+++ b/examples/apollo/test/index.spec.ts
@@ -62,9 +62,7 @@ describe('startup', () => {
 
     const query = body.singleResult;
     expect(query.errors).toBeDefined();
-    expect(query.errors?.map((e) => e.message)).toContain(
-      'Syntax Error: Query Cost limit of 100 exceeded, found 138.',
-    );
+    expect(query.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 138.');
   });
 
   it('should block field suggestion', async () => {

--- a/examples/apollo/test/index.spec.ts
+++ b/examples/apollo/test/index.spec.ts
@@ -63,7 +63,7 @@ describe('startup', () => {
     const query = body.singleResult;
     expect(query.errors).toBeDefined();
     expect(query.errors?.map((e) => e.message)).toContain(
-      'Syntax Error: Query Cost limit of 100 exceeded, found 5023.',
+      'Syntax Error: Query Cost limit of 100 exceeded, found 138.',
     );
   });
 

--- a/examples/yoga/test/index.spec.ts
+++ b/examples/yoga/test/index.spec.ts
@@ -68,7 +68,7 @@ describe('startup', () => {
     const body = JSON.parse(response.text);
     expect(body.data?.books).toBeUndefined();
     expect(body.errors).toBeDefined();
-    expect(body.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 5023.');
+    expect(body.errors?.map((e) => e.message)).toContain('Syntax Error: Query Cost limit of 100 exceeded, found 138.');
   });
 
   it('should disable field suggestion', async () => {

--- a/packages/plugins/cost-limit/src/index.ts
+++ b/packages/plugins/cost-limit/src/index.ts
@@ -95,8 +95,8 @@ class CostLimitVisitor {
 
     if (node.kind == Kind.FRAGMENT_SPREAD) {
       if (this.visitedFragments.has(node.name.value)) {
-        const visitCost = this.visitedFragments.get(node.name.value) ?? 0
-        return cost + (this.config.depthCostFactor * visitCost);
+        const visitCost = this.visitedFragments.get(node.name.value) ?? 0;
+        return cost + this.config.depthCostFactor * visitCost;
       } else {
         this.visitedFragments.set(node.name.value, -1);
       }

--- a/packages/plugins/cost-limit/test/index.spec.ts
+++ b/packages/plugins/cost-limit/test/index.spec.ts
@@ -167,8 +167,6 @@ describe('global', () => {
     `);
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
-    expect(result.errors?.map((error) => error.message)).toContain(
-      'Cannot spread fragment "A" within itself via "B".',
-    );
+    expect(result.errors?.map((error) => error.message)).toContain('Cannot spread fragment "A" within itself via "B".');
   });
 });

--- a/packages/plugins/cost-limit/test/index.spec.ts
+++ b/packages/plugins/cost-limit/test/index.spec.ts
@@ -168,7 +168,7 @@ describe('global', () => {
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
     expect(result.errors?.map((error) => error.message)).toContain(
-      'Syntax Error: Query Cost limit of 50 exceeded, found 16050.',
+      'Cannot spread fragment "A" within itself via "B".',
     );
   });
 });

--- a/packages/plugins/max-directives/src/index.ts
+++ b/packages/plugins/max-directives/src/index.ts
@@ -26,7 +26,7 @@ class MaxDirectivesVisitor {
 
   private readonly context: ValidationContext;
   private readonly config: Required<MaxDirectivesOptions>;
-  private readonly visitedFragments: Set<string> = new Set();
+  private readonly visitedFragments: Map<string, number>;
 
   constructor(context: ValidationContext, options?: MaxDirectivesOptions) {
     this.context = context;
@@ -35,6 +35,7 @@ class MaxDirectivesVisitor {
       maxDirectivesDefaultOptions,
       ...Object.entries(options ?? {}).map(([k, v]) => (v === undefined ? {} : { [k]: v })),
     );
+    this.visitedFragments = new Map();
 
     this.OperationDefinition = {
       enter: this.onOperationDefinitionEnter,
@@ -73,12 +74,17 @@ class MaxDirectivesVisitor {
       }
     } else if (node.kind == Kind.FRAGMENT_SPREAD) {
       if (this.visitedFragments.has(node.name.value)) {
-        return 0;
+        return this.visitedFragments.get(node.name.value) ?? 0;
+      } else {
+        this.visitedFragments.set(node.name.value, -1);
       }
-      this.visitedFragments.add(node.name.value);
       const fragment = this.context.getFragment(node.name.value);
       if (fragment) {
-        directives += this.countDirectives(fragment);
+        const additionalDirectives = this.countDirectives(fragment);
+        if (this.visitedFragments.get(node.name.value) === -1) {
+          this.visitedFragments.set(node.name.value, additionalDirectives);
+        }
+        directives += additionalDirectives;
       }
     }
     return directives;


### PR DESCRIPTION
Fix fragments visitor where inline fragments were inferred as recursive ones.
This breaking behavior has been introduced in a previous release patching recursive fragment.

This MR address both the fragment cache calculation for visitor plugins and make the `fragmentRecursion` cost deprecated.
We will prefer handling recursive fragments check through GraphQL JS.

Thanks @simoncrypta @dthyresson for the catch.