### PR TITLE
chore: drop node 14 and require node 16 or higher

### DIFF
--- a/.changeset/long-cougars-warn.md
+++ b/.changeset/long-cougars-warn.md
@@ -10,4 +10,4 @@
 '@escape.tech/graphql-armor-types': minor
 ---
 
-- chore(deps): Update envelop (major) #418
+- chore(deps): Update envelop (major)

--- a/.changeset/modern-toys-own.md
+++ b/.changeset/modern-toys-own.md
@@ -9,4 +9,4 @@
 '@escape.tech/graphql-armor': major
 ---
 
-Drop support for node 14 and require node 16 or higher.
+- Drop support for node 14 and require node 16 or higher. 

--- a/.changeset/modern-toys-own.md
+++ b/.changeset/modern-toys-own.md
@@ -1,0 +1,12 @@
+---
+'@escape.tech/graphql-armor-block-field-suggestions': major
+'@escape.tech/graphql-armor-character-limit': major
+'@escape.tech/graphql-armor-max-directives': major
+'@escape.tech/graphql-armor-max-aliases': major
+'@escape.tech/graphql-armor-cost-limit': major
+'@escape.tech/graphql-armor-max-tokens': major
+'@escape.tech/graphql-armor-max-depth': major
+'@escape.tech/graphql-armor': major
+---
+
+Drop support for node 14 and require node 16 or higher.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 17, 18]
+        node: [16, 18, 20]
 
     name: Examples Node ${{ matrix.node }}
     steps:

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
         "node": "18.16.0",
         "yarn": "1.22.19"
     },
+    "engines": {
+        "node": ">=16.0.0"
+    },
     "packageManager": "yarn@3.5.1",
     "preconstruct": {
         "packages": [

--- a/packages/graphql-armor/package.json
+++ b/packages/graphql-armor/package.json
@@ -30,6 +30,9 @@
     "url": "https://github.com/Escape-Technologies/graphql-armor/issues"
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "@escape.tech/graphql-armor-block-field-suggestions": "1.4.1",
     "@escape.tech/graphql-armor-cost-limit": "1.7.3",

--- a/packages/plugins/block-field-suggestions/package.json
+++ b/packages/plugins/block-field-suggestions/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/Escape-Technologies/graphql-armor/issues"
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "graphql": "^16.0.0"
   },

--- a/packages/plugins/character-limit/package.json
+++ b/packages/plugins/character-limit/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/Escape-Technologies/graphql-armor/issues"
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "graphql": "^16.0.0"
   },

--- a/packages/plugins/cost-limit/package.json
+++ b/packages/plugins/cost-limit/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/Escape-Technologies/graphql-armor/issues"
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "graphql": "^16.0.0"
   },

--- a/packages/plugins/max-aliases/package.json
+++ b/packages/plugins/max-aliases/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/Escape-Technologies/graphql-armor/issues"
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "graphql": "^16.0.0"
   },

--- a/packages/plugins/max-depth/package.json
+++ b/packages/plugins/max-depth/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/Escape-Technologies/graphql-armor/issues"
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "graphql": "^16.0.0"
   },

--- a/packages/plugins/max-directives/package.json
+++ b/packages/plugins/max-directives/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/Escape-Technologies/graphql-armor/issues"
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "graphql": "^16.0.0"
   },

--- a/packages/plugins/max-tokens/package.json
+++ b/packages/plugins/max-tokens/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/Escape-Technologies/graphql-armor/issues"
   },
   "homepage": "https://github.com/Escape-Technologies/graphql-armor",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "graphql": "^16.0.0"
   },


### PR DESCRIPTION
In #418, envelop has fixed its minimal version to node 16.

[Node 14 has reached its EOL](https://github.com/nodejs/release#release-schedule), we are dropping its support too.