### PR TITLE
Remove the found count from the max tokens plugin. 

### DIFF
--- a/.changeset/weak-dolphins-shout.md
+++ b/.changeset/weak-dolphins-shout.md
@@ -1,0 +1,6 @@
+---
+'@escape.tech/graphql-armor-max-tokens': minor
+'@escape.tech/graphql-armor': minor
+---
+
+Remove the found count from the max tokens plugin. [#430](https://github.com/Escape-Technologies/graphql-armor/pull/430)

--- a/examples/apollo-v3/test/index.spec.ts
+++ b/examples/apollo-v3/test/index.spec.ts
@@ -32,7 +32,7 @@ describe('startup', () => {
       });
       expect(false).toBe(true);
     } catch (e) {
-      expect(e.message).toContain(`Syntax Error: Token limit of ${maxTokens} exceeded, found ${maxTokens + 1}.`);
+      expect(e.message).toContain(`Syntax Error: Token limit of ${maxTokens} exceeded.`);
     }
   });
 

--- a/examples/apollo/test/index.spec.ts
+++ b/examples/apollo/test/index.spec.ts
@@ -36,7 +36,7 @@ describe('startup', () => {
       });
       expect(false).toBe(true);
     } catch (e) {
-      expect(e.message).toContain(`Syntax Error: Token limit of ${maxTokens} exceeded, found ${maxTokens + 1}.`);
+      expect(e.message).toContain(`Syntax Error: Token limit of ${maxTokens} exceeded.`);
     }
   });
 

--- a/examples/yoga/test/index.spec.ts
+++ b/examples/yoga/test/index.spec.ts
@@ -39,7 +39,7 @@ describe('startup', () => {
     expect(body.data?.books).toBeUndefined();
     expect(body.errors).toBeDefined();
     expect(body.errors?.map((e) => e.message)).toContain(
-      `Syntax Error: Token limit of ${maxTokens} exceeded, found ${maxTokens + 1}.`,
+      `Syntax Error: Token limit of ${maxTokens} exceeded.`,
     );
   });
 

--- a/examples/yoga/test/index.spec.ts
+++ b/examples/yoga/test/index.spec.ts
@@ -38,9 +38,7 @@ describe('startup', () => {
     const body = JSON.parse(response.text);
     expect(body.data?.books).toBeUndefined();
     expect(body.errors).toBeDefined();
-    expect(body.errors?.map((e) => e.message)).toContain(
-      `Syntax Error: Token limit of ${maxTokens} exceeded.`,
-    );
+    expect(body.errors?.map((e) => e.message)).toContain(`Syntax Error: Token limit of ${maxTokens} exceeded.`);
   });
 
   it('should have cost limit', async () => {

--- a/packages/plugins/max-tokens/src/index.ts
+++ b/packages/plugins/max-tokens/src/index.ts
@@ -47,7 +47,7 @@ export class MaxTokensParserWLexer extends Parser {
               const err = syntaxError(
                 this._lexer.source,
                 token.start,
-                `Token limit of ${this.config.n} exceeded, found ${this._tokenCount}.`,
+                `Token limit of ${this.config.n} exceeded.`,
               );
 
               for (const handler of this.config.onReject) {

--- a/packages/plugins/max-tokens/src/index.ts
+++ b/packages/plugins/max-tokens/src/index.ts
@@ -44,11 +44,7 @@ export class MaxTokensParserWLexer extends Parser {
             }
 
             if (this._tokenCount > this.config.n) {
-              const err = syntaxError(
-                this._lexer.source,
-                token.start,
-                `Token limit of ${this.config.n} exceeded.`,
-              );
+              const err = syntaxError(this._lexer.source, token.start, `Token limit of ${this.config.n} exceeded.`);
 
               for (const handler of this.config.onReject) {
                 handler(null, err);

--- a/packages/plugins/max-tokens/test/index.spec.ts
+++ b/packages/plugins/max-tokens/test/index.spec.ts
@@ -27,7 +27,7 @@ describe('global', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors).toHaveLength(1);
     expect(result.errors?.[0].message).toEqual(
-      `Syntax Error: Token limit of ${maxTokenDefaultOptions.n} exceeded, found ${maxTokenDefaultOptions.n + 1}.`,
+      `Syntax Error: Token limit of ${maxTokenDefaultOptions.n} exceeded.`,
     );
   });
   it('does not rejects an operation below the max token count', async () => {
@@ -45,7 +45,7 @@ describe('global', () => {
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
     expect(result.errors).toHaveLength(1);
-    expect(result.errors?.[0].message).toEqual('Syntax Error: Token limit of 4 exceeded, found 5.');
+    expect(result.errors?.[0].message).toEqual('Syntax Error: Token limit of 4 exceeded.');
   });
   it('does not rejects an operation below the max token count (user provided)', async () => {
     const count = 4;

--- a/packages/plugins/max-tokens/test/index.spec.ts
+++ b/packages/plugins/max-tokens/test/index.spec.ts
@@ -26,9 +26,7 @@ describe('global', () => {
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
     expect(result.errors).toHaveLength(1);
-    expect(result.errors?.[0].message).toEqual(
-      `Syntax Error: Token limit of ${maxTokenDefaultOptions.n} exceeded.`,
-    );
+    expect(result.errors?.[0].message).toEqual(`Syntax Error: Token limit of ${maxTokenDefaultOptions.n} exceeded.`);
   });
   it('does not rejects an operation below the max token count', async () => {
     const operation = `{ ${Array(maxTokenDefaultOptions.n - 2).join('a ')} }`;


### PR DESCRIPTION
### Description
The max tokens plugins error message includes a found count that is always +1 of the allowed count because it stops parsing the document after it exceeds the allowed count. 

We could obviously parse the entire document and return the total count but this seems like wasted cycles to calculate the total number of tokens. 