### PR TITLE
feat: add flattenFragments option to max-depth

### DIFF
--- a/.changeset/many-phones-tan.md
+++ b/.changeset/many-phones-tan.md
@@ -1,0 +1,6 @@
+---
+'@escape.tech/graphql-armor-max-depth': minor
+'@escape.tech/graphql-armor': minor
+---
+
+Add flattenFragments option to max-depth plugin. [#436](https://github.com/Escape-Technologies/graphql-armor/pull/436)

--- a/services/docs/docs/plugins/max-depth.md
+++ b/services/docs/docs/plugins/max-depth.md
@@ -20,11 +20,14 @@ GraphQLArmor({
     // Toogle the plugin | default: true
     enabled?: boolean,
     
-    // Directives threshold | default: 6
+    // Depth threshold | default: 6
     n?: int,
 
     // Ignore the depth of introspection queries | default: true
     ignoreIntrospection?: boolean,
+
+    // Flatten frament spreads and inline framents for the depth count | default: false
+    flattenFragments?: boolean,
 
     // Callbacks that are ran whenever a Query is accepted
     onAccept?: GraphQLArmorAcceptCallback[],


### PR DESCRIPTION
#431

### Description

Provides a new option to the Max Depth plugin - `flattenFragments`, defaulted to `false`.

When set to `true`, the max depth plugin will ignore nodes of kind `INLINE_FRAGMENT` and `FRAGMENT_SPREAD` when performing the depth calculation, so that the depth will be considered the same regardless of the usage of fragments.