### PR TITLE
feat(max-aliases): add an allow list of unlimited aliases name

### DIFF
--- a/.changeset/cyan-crews-do.md
+++ b/.changeset/cyan-crews-do.md
@@ -1,0 +1,5 @@
+---
+'@escape.tech/graphql-armor-max-aliases': minor
+---
+
+add allowList

--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -11,12 +11,13 @@ import {
   ValidationContext,
 } from 'graphql';
 
-type MaxAliasesOptions = { n?: number } & GraphQLArmorCallbackConfiguration;
+type MaxAliasesOptions = { n?: number; allowList: string[] } & GraphQLArmorCallbackConfiguration;
 const maxAliasesDefaultOptions: Required<MaxAliasesOptions> = {
   n: 15,
   onAccept: [],
   onReject: [],
   propagateOnRejection: true,
+  allowList: [],
 };
 
 class MaxAliasesVisitor {
@@ -63,7 +64,7 @@ class MaxAliasesVisitor {
     node: FieldNode | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode | FragmentSpreadNode,
   ): number {
     let aliases = 0;
-    if ('alias' in node && node.alias) {
+    if ('alias' in node && node.alias && !this.config.allowList.includes(node.alias.value)) {
       ++aliases;
     }
     if ('selectionSet' in node && node.selectionSet) {

--- a/packages/plugins/max-aliases/test/index.spec.ts
+++ b/packages/plugins/max-aliases/test/index.spec.ts
@@ -122,4 +122,20 @@ describe('global', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.map((error) => error.message)).toContain('Cannot spread fragment "A" within itself via "B".');
   });
+
+  it('should not reject allowed aliases', async () => {
+    const maxAliases = 1;
+    const testkit = createTestkit([maxAliasesPlugin({ n: maxAliases, allowList: ['allowed'] })], schema);
+    const result = await testkit.execute(`query {
+      allowed: getBook(title: "null") {
+        allowed: author
+      }
+    }`);
+
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      allowed: null,
+    });
+  });
 });


### PR DESCRIPTION
## Description

This PR aims to add an allow list of alias names that are not counted in the number of aliases.

## Why

To provide a more robust way of keeping track of cached entities, the `@envelop/response-cache` plugin rely on aliases added server side to every query documents. This allows us to ensure we have access to `__typename` and `id` of each composite object selected in the query.

But unfortunately, this doesn't play nicely with the `max-aliases` plugin, since any query will quickly use a lot of aliases.

## Other solutions

I have though about another solution: an allow list of field that can always be aliased. But I think that this is way less safe because someone could add any number of aliases, while the proposed solution only opens the possibility to add defined aliases to every selection set.