### PR TITLE
Fix: mark MaxAliasesOptions allowList property as optional

### DIFF
--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -11,7 +11,7 @@ import {
   ValidationContext,
 } from 'graphql';
 
-type MaxAliasesOptions = { n?: number; allowList: string[] } & GraphQLArmorCallbackConfiguration;
+type MaxAliasesOptions = { n?: number; allowList?: string[] } & GraphQLArmorCallbackConfiguration;
 const maxAliasesDefaultOptions: Required<MaxAliasesOptions> = {
   n: 15,
   onAccept: [],


### PR DESCRIPTION
The `allowList` property of the `MaxAliasesOptions` type is currently marked as required. `maxAliasesDefaultOptions` provides a default of `allowList: []`, therefore the `allowList` option property should be marked as optional.

Currently, to satisfy type checking, consumers must explicitly pass an empty array for `allowList` when configuring `maxAliasesPlugin`.

Simple fix, just marking the property as optional :+1: 