### PR TITLE
Feat/block suggestions plugin/remove extra chars

### DIFF
--- a/.changeset/long-peas-develop.md
+++ b/.changeset/long-peas-develop.md
@@ -1,0 +1,5 @@
+---
+'@escape.tech/graphql-armor-block-field-suggestions': major
+---
+
+feat(field-suggestion): remove extra chars

--- a/examples/yoga/test/index.spec.ts
+++ b/examples/yoga/test/index.spec.ts
@@ -88,7 +88,7 @@ describe('startup', () => {
     expect(body.data?.books).toBeUndefined();
     expect(body.errors).toBeDefined();
     expect(body.errors?.map((e) => e.message)).toContain(
-      'Cannot query field "titlee" on type "Book". [Suggestion hidden]?',
+      'Cannot query field "titlee" on type "Book". [Suggestion hidden]',
     );
   });
 

--- a/packages/plugins/block-field-suggestions/src/index.ts
+++ b/packages/plugins/block-field-suggestions/src/index.ts
@@ -8,7 +8,7 @@ const blockFieldSuggestionsDefaultOptions: Required<BlockFieldSuggestionsOptions
 
 const formatter = (error: GraphQLError, mask: string): GraphQLError => {
   if (error instanceof GraphQLError) {
-    error.message = error.message.replace(/Did you mean ".+"/g, mask);
+    error.message = error.message.replace(/Did you mean ".+"\?/g, mask);
   }
   return error as GraphQLError;
 };

--- a/packages/plugins/block-field-suggestions/src/index.ts
+++ b/packages/plugins/block-field-suggestions/src/index.ts
@@ -8,7 +8,7 @@ const blockFieldSuggestionsDefaultOptions: Required<BlockFieldSuggestionsOptions
 
 const formatter = (error: GraphQLError, mask: string): GraphQLError => {
   if (error instanceof GraphQLError) {
-    error.message = error.message.replace(/Did you mean ".+"\?/g, mask);
+    error.message = error.message.replace(/Did you mean ".+"\?/g, mask).trim();
   }
   return error as GraphQLError;
 };

--- a/packages/plugins/block-field-suggestions/test/index.spec.ts
+++ b/packages/plugins/block-field-suggestions/test/index.spec.ts
@@ -84,7 +84,7 @@ describe('global', () => {
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
     expect(result.errors?.map((error) => error.message)).toEqual([
-      'Cannot query field "titlee" on type "Book". [Suggestion hidden]?',
+      'Cannot query field "titlee" on type "Book". [Suggestion hidden]',
     ]);
   });
 
@@ -95,7 +95,7 @@ describe('global', () => {
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
     expect(result.errors?.map((error) => error.message)).toEqual([
-      'Cannot query field "titlee" on type "Book". <[REDACTED]>?',
+      'Cannot query field "titlee" on type "Book". <[REDACTED]>',
     ]);
   });
 });

--- a/packages/plugins/block-field-suggestions/test/index.spec.ts
+++ b/packages/plugins/block-field-suggestions/test/index.spec.ts
@@ -98,4 +98,15 @@ describe('global', () => {
       'Cannot query field "titlee" on type "Book". <[REDACTED]>',
     ]);
   });
+
+  it('should use remove suggestion completely with emptry string for mask', async () => {
+    const testkit = createTestkit([blockFieldSuggestionsPlugin({ mask: '' })], schema);
+    const result = await testkit.execute(query);
+
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      'Cannot query field "titlee" on type "Book".',
+    ]);
+  });
 });

--- a/packages/plugins/block-field-suggestions/test/index.spec.ts
+++ b/packages/plugins/block-field-suggestions/test/index.spec.ts
@@ -105,8 +105,6 @@ describe('global', () => {
 
     assertSingleExecutionValue(result);
     expect(result.errors).toBeDefined();
-    expect(result.errors?.map((error) => error.message)).toEqual([
-      'Cannot query field "titlee" on type "Book".',
-    ]);
+    expect(result.errors?.map((error) => error.message)).toEqual(['Cannot query field "titlee" on type "Book".']);
   });
 });


### PR DESCRIPTION
resolves #729 

* remove extra question mark character from the end of blocked suggestions
* remove trailing whitespace after hiding suggestion