### PR TITLE
Add a new optional parameter ignoreFields to the maxAliases plugin

### DIFF
--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -16,6 +16,7 @@ type MaxAliasesOptions = {
   allowList?: string[];
   exposeLimits?: boolean;
   errorMessage?: string;
+  ignoreFields?: string[];
 } & GraphQLArmorCallbackConfiguration;
 
 const maxAliasesDefaultOptions: Required<MaxAliasesOptions> = {
@@ -26,6 +27,7 @@ const maxAliasesDefaultOptions: Required<MaxAliasesOptions> = {
   onAccept: [],
   onReject: [],
   propagateOnRejection: true,
+  ignoreFields: ['__typename'],
 };
 
 class MaxAliasesVisitor {
@@ -78,7 +80,7 @@ class MaxAliasesVisitor {
     if (
       'alias' in node &&
       node.alias &&
-      node.name.value !== '__typename' &&
+      !this.config.ignoreFields.includes(node.name.value) &&
       !this.config.allowList.includes(node.alias.value)
     ) {
       ++aliases;

--- a/packages/plugins/max-aliases/test/index.spec.ts
+++ b/packages/plugins/max-aliases/test/index.spec.ts
@@ -103,6 +103,25 @@ describe('maxAliasesPlugin', () => {
     });
   });
 
+  it('counts __typename aliases against limit when ignoreFields is passed', async () => {
+    const maxAliases = 1;
+    const testkit = createTestkit([maxAliasesPlugin({ n: maxAliases, ignoreFields: [] })], schema);
+    const result = await testkit.execute(/* GraphQL */ `
+      query A {
+        getBook(title: "null") {
+          typenameA: __typename
+          typenameB: __typename
+        }
+      }
+    `);
+
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      `Syntax Error: Aliases limit of ${maxAliases} exceeded, found ${maxAliases + 1}.`,
+    ]);
+  });
+
   it('respects fragment aliases', async () => {
     const maxAliases = 1;
     const testkit = createTestkit([maxAliasesPlugin({ n: maxAliases })], schema);

--- a/services/docs/docs/plugins/max-aliases.md
+++ b/services/docs/docs/plugins/max-aliases.md
@@ -33,6 +33,9 @@ GraphQLArmorConfig({
 
     // List of queries that are allowed to bypass the plugin
     allowList?: string[],
+
+    // List of fields that can be aliased without counting against the alias threshold | default ['__typename']
+    ignoreFields?: string[],
   }
 })
 ```


### PR DESCRIPTION
Closes #738

There is a GraphQL vulnerability related to allowing an unlimited number of aliases of `__typename` - an attacker can craft a query that consists of tens of thousands of aliases, like `{"query": "query aliasOverLoad { alias0: __typename alias1: __typename alias2: __typename alias3: __typename alias4: __typename alias5: __typename <...thousands more> }"}` and can be a way to bypass authentication on the API because it does not hit any resolvers. With enough simultaneous queries like this it can fairly easily bring down a server.

This PR adds `ignoreFields` to the options of max-aliases and sets the default value to `["__typename"]` to ensure backwards compatibility. By passing an empty array the plugin will count aliases of `__typename` against the max alias limit.