### PR TITLE
fix: add __typename to the default value of allowList

### DIFF
--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -20,7 +20,7 @@ type MaxAliasesOptions = {
 
 const maxAliasesDefaultOptions: Required<MaxAliasesOptions> = {
   n: 15,
-  allowList: [],
+  allowList: ['__typename'],
   exposeLimits: true,
   errorMessage: 'Query validation error.',
   onAccept: [],
@@ -78,8 +78,8 @@ class MaxAliasesVisitor {
     if (
       'alias' in node &&
       node.alias &&
-      node.name.value !== '__typename' &&
-      !this.config.allowList.includes(node.alias.value)
+      !this.config.allowList.includes(node.alias.value) &&
+      !this.config.allowList.includes(node.name.value)
     ) {
       ++aliases;
     }

--- a/packages/plugins/max-aliases/test/index.spec.ts
+++ b/packages/plugins/max-aliases/test/index.spec.ts
@@ -103,6 +103,26 @@ describe('maxAliasesPlugin', () => {
     });
   });
 
+  it('counts __typename aliases against limit when not included in allowList', async () => {
+    const maxAliases = 1;
+    const allowList = [];
+    const testkit = createTestkit([maxAliasesPlugin({ n: maxAliases, allowList })], schema);
+    const result = await testkit.execute(/* GraphQL */ `
+      query A {
+        getBook(title: "null") {
+          typenameA: __typename
+          typenameB: __typename
+        }
+      }
+    `);
+
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      `Syntax Error: Aliases limit of ${maxAliases} exceeded, found ${maxAliases + 1}.`,
+    ]);
+  });
+
   it('respects fragment aliases', async () => {
     const maxAliases = 1;
     const testkit = createTestkit([maxAliasesPlugin({ n: maxAliases })], schema);

--- a/services/docs/docs/plugins/max-aliases.md
+++ b/services/docs/docs/plugins/max-aliases.md
@@ -31,7 +31,7 @@ GraphQLArmorConfig({
     // Do you want to propagate the rejection to the client? | default: true
     propagateOnRejection?: boolean,
 
-    // List of queries that are allowed to bypass the plugin
+    // List of queries that are allowed to bypass the plugin | default: ['__typename']
     allowList?: string[],
   }
 })


### PR DESCRIPTION
Closes #738, supersedes #766

There is a GraphQL vulnerability related to allowing an unlimited number of aliases of `__typename` - an attacker can craft a query that consists of tens of thousands of aliases, like `{"query": "query aliasOverLoad { alias0: __typename alias1: __typename alias2: __typename alias3: __typename alias4: __typename alias5: __typename <...thousands more> }"}` and can be a way to bypass authentication on the API because it does not hit any resolvers. With enough simultaneous queries like this it can fairly easily bring down a server.

In #468 the behavior of the max aliases plugin was modified to permanently omit aliases of `__typename` from the alias count. This PR builds on those changes by setting the default value of `allowList` to `["__typename"]` so that consumers can opt out of this behavior, while maintaining backwards compatibility. 
