### PR TITLE
fix: cost-limit ignore only Field Node named `__schema`

### DIFF
--- a/packages/plugins/cost-limit/src/index.ts
+++ b/packages/plugins/cost-limit/src/index.ts
@@ -85,7 +85,12 @@ class CostLimitVisitor {
     node: FieldNode | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode | FragmentSpreadNode,
     depth = 0,
   ): number {
-    if (this.config.ignoreIntrospection && 'name' in node && node.name?.value === '__schema' && node.kind === Kind.FIELD) {
+    if (
+      this.config.ignoreIntrospection &&
+      'name' in node &&
+      node.name?.value === '__schema' &&
+      node.kind === Kind.FIELD
+    ) {
       return 0;
     }
 

--- a/packages/plugins/cost-limit/src/index.ts
+++ b/packages/plugins/cost-limit/src/index.ts
@@ -85,7 +85,7 @@ class CostLimitVisitor {
     node: FieldNode | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode | FragmentSpreadNode,
     depth = 0,
   ): number {
-    if (this.config.ignoreIntrospection && 'name' in node && node.name?.value === '__schema') {
+    if (this.config.ignoreIntrospection && 'name' in node && node.name?.value === '__schema' && node.kind === Kind.FIELD) {
       return 0;
     }
 

--- a/packages/plugins/cost-limit/test/index.spec.ts
+++ b/packages/plugins/cost-limit/test/index.spec.ts
@@ -162,7 +162,7 @@ describe('costLimitPlugin', () => {
       ],
       schema,
     );
-    const x = getIntrospectionQuery()
+    const x = getIntrospectionQuery();
     const result = await testkit.execute(getIntrospectionQuery());
 
     assertSingleExecutionValue(result);


### PR DESCRIPTION
This PR fixes a bypass to the cost-limit plugin (in default settings) by skipping only nodes of type `Field` when `ignoreIntrospection` is set.

This will fix the following type of bypasses:

```gql
query  {
  ...__schema
}

fragment __schema on Query {
  books {
    title
    author
  }
}
```

```gql
query __schema {
  books {
    title
    author
  }
}
```