### PR TITLE
Revert "chore: bump gql armor to 3.1.4 with cost-limit bump"

### DIFF
--- a/.changeset/rude-laws-yawn.md
+++ b/.changeset/rude-laws-yawn.md
@@ -1,6 +1,0 @@
----
-'@escape.tech/graphql-armor-cost-limit': minor
-'@escape.tech/graphql-armor': minor
----
-
-Bump cost-limit to 2.4.1 to fix GHSA-733v-p3h5-qpq7

--- a/packages/graphql-armor/CHANGELOG.md
+++ b/packages/graphql-armor/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @escape.tech/graphql-armor
 
-## 3.1.4
-
-### Patch Changes
-
-- Updated dependencies
-  - @escape.tech/graphql-armor-cost-limit@2.4.1
-
-- 5a32954: Fix security advisory GHSA-733v-p3h5-qpq7 related to cost-limit bypass.
-
 ## 3.1.3
 
 ### Patch Changes

--- a/packages/graphql-armor/package.json
+++ b/packages/graphql-armor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escape.tech/graphql-armor",
-  "version": "3.1.4",
+  "version": "3.1.3",
   "description": "Dead-simple, yet highly customizable security middleware for Apollo GraphQL servers shield",
   "keywords": [
     "apollo",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@escape.tech/graphql-armor-block-field-suggestions": "3.0.0",
-    "@escape.tech/graphql-armor-cost-limit": "2.4.1",
+    "@escape.tech/graphql-armor-cost-limit": "2.4.0",
     "@escape.tech/graphql-armor-max-aliases": "2.6.1",
     "@escape.tech/graphql-armor-max-depth": "2.4.0",
     "@escape.tech/graphql-armor-max-directives": "2.3.0",

--- a/packages/plugins/cost-limit/CHANGELOG.md
+++ b/packages/plugins/cost-limit/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @escape.tech/graphql-armor-cost-limit
 
-## 2.4.1
-
-### Minor Changes
-
-- 5a32954: Fix security advisory GHSA-733v-p3h5-qpq7 related to cost-limit bypass.
-
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/plugins/cost-limit/package.json
+++ b/packages/plugins/cost-limit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escape.tech/graphql-armor-cost-limit",
-  "version": "2.4.1",
+  "version": "2.4.0",
   "description": "Limit the cost of a GraphQL Query.",
   "packageManager": "yarn@4.5.0",
   "main": "dist/graphql-armor-cost-limit.cjs.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4356,7 +4356,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@escape.tech/graphql-armor-cost-limit@npm:2.4.1, @escape.tech/graphql-armor-cost-limit@workspace:packages/plugins/cost-limit":
+"@escape.tech/graphql-armor-cost-limit@npm:2.4.0, @escape.tech/graphql-armor-cost-limit@workspace:packages/plugins/cost-limit":
   version: 0.0.0-use.local
   resolution: "@escape.tech/graphql-armor-cost-limit@workspace:packages/plugins/cost-limit"
   dependencies:
@@ -4490,7 +4490,7 @@ __metadata:
     "@apollo/server": "npm:4.12.0"
     "@envelop/core": "npm:5.2.3"
     "@escape.tech/graphql-armor-block-field-suggestions": "npm:3.0.0"
-    "@escape.tech/graphql-armor-cost-limit": "npm:2.4.1"
+    "@escape.tech/graphql-armor-cost-limit": "npm:2.4.0"
     "@escape.tech/graphql-armor-max-aliases": "npm:2.6.1"
     "@escape.tech/graphql-armor-max-depth": "npm:2.4.0"
     "@escape.tech/graphql-armor-max-directives": "npm:2.3.0"


### PR DESCRIPTION
Reverts Escape-Technologies/graphql-armor#791 due to release process