### PR TITLE
Inherit the plugin context from envelop

### DIFF
--- a/.changeset/sweet-grapes-leave.md
+++ b/.changeset/sweet-grapes-leave.md
@@ -1,0 +1,12 @@
+---
+'@escape.tech/graphql-armor-block-field-suggestions': patch
+'@escape.tech/graphql-armor-character-limit': patch
+'@escape.tech/graphql-armor-max-directives': patch
+'@escape.tech/graphql-armor-max-aliases': patch
+'@escape.tech/graphql-armor-cost-limit': patch
+'@escape.tech/graphql-armor-max-tokens': patch
+'@escape.tech/graphql-armor-max-depth': patch
+'@escape.tech/graphql-armor': patch
+---
+
+Inherit the plugin context from envelop

--- a/packages/graphql-armor/src/envelop/armor.ts
+++ b/packages/graphql-armor/src/envelop/armor.ts
@@ -1,4 +1,4 @@
-import type { OnPluginInitEventPayload, Plugin } from '@envelop/core';
+import type { Plugin } from '@envelop/core';
 import type { GraphQLArmorConfig } from '@escape.tech/graphql-armor-types';
 
 import { EnvelopProtection } from './protections/base-protection';
@@ -9,12 +9,14 @@ import { EnvelopMaxDepthProtection } from './protections/max-depth';
 import { EnvelopMaxDirectivesProtection } from './protections/max-directives';
 import { EnvelopMaxTokensProtection } from './protections/max-tokens';
 
-export const EnvelopArmorPlugin = (config?: GraphQLArmorConfig): Plugin => {
-  const armor = new EnvelopArmor(config);
+export const EnvelopArmorPlugin = <PluginContext extends Record<string, any> = {}>(
+  config?: GraphQLArmorConfig,
+): Plugin<PluginContext> => {
+  const armor = new EnvelopArmor<PluginContext>(config);
   const enhancements = armor.protect();
 
   return {
-    onPluginInit({ addPlugin }: OnPluginInitEventPayload) {
+    onPluginInit({ addPlugin }) {
       for (const plugin of enhancements.plugins) {
         addPlugin(plugin);
       }
@@ -22,8 +24,8 @@ export const EnvelopArmorPlugin = (config?: GraphQLArmorConfig): Plugin => {
   };
 };
 
-export class EnvelopArmor {
-  private readonly protections: EnvelopProtection[];
+export class EnvelopArmor<PluginContext extends Record<string, any> = {}> {
+  private readonly protections: EnvelopProtection<PluginContext>[];
 
   constructor(config: GraphQLArmorConfig = {}) {
     this.protections = [
@@ -37,9 +39,9 @@ export class EnvelopArmor {
   }
 
   protect(): {
-    plugins: Plugin[];
+    plugins: Plugin<PluginContext>[];
   } {
-    const plugins: Plugin[] = [];
+    const plugins: Plugin<PluginContext>[] = [];
 
     for (const protection of this.protections) {
       if (protection.isEnabled) {

--- a/packages/graphql-armor/src/envelop/protections/base-protection.ts
+++ b/packages/graphql-armor/src/envelop/protections/base-protection.ts
@@ -1,11 +1,11 @@
 import type { Plugin as EnvelopPlugin } from '@envelop/core';
 import type { GraphQLArmorConfig } from '@escape.tech/graphql-armor-types';
 
-export type EnvelopConfigurationEnhancement = {
-  plugins: EnvelopPlugin[];
+export type EnvelopConfigurationEnhancement<PluginContext extends Record<string, any> = {}> = {
+  plugins: EnvelopPlugin<PluginContext>[];
 };
 
-export abstract class EnvelopProtection {
+export abstract class EnvelopProtection<PluginContext extends Record<string, any> = {}> {
   config: GraphQLArmorConfig;
   enabledByDefault = true;
 
@@ -13,6 +13,6 @@ export abstract class EnvelopProtection {
     this.config = config;
   }
 
-  abstract protect(): EnvelopConfigurationEnhancement;
+  abstract protect(): EnvelopConfigurationEnhancement<PluginContext>;
   abstract get isEnabled(): boolean;
 }

--- a/packages/graphql-armor/src/envelop/protections/block-field-suggestion.ts
+++ b/packages/graphql-armor/src/envelop/protections/block-field-suggestion.ts
@@ -2,7 +2,9 @@ import { blockFieldSuggestionsPlugin } from '@escape.tech/graphql-armor-block-fi
 
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
-export class EnvelopBlockFieldSuggestionProtection extends EnvelopProtection {
+export class EnvelopBlockFieldSuggestionProtection<
+  PluginContext extends Record<string, any> = {},
+> extends EnvelopProtection<PluginContext> {
   get isEnabled(): boolean {
     if (!this.config.blockFieldSuggestion) {
       return this.enabledByDefault;
@@ -10,7 +12,7 @@ export class EnvelopBlockFieldSuggestionProtection extends EnvelopProtection {
     return this.config.blockFieldSuggestion.enabled ?? this.enabledByDefault;
   }
 
-  protect(): EnvelopConfigurationEnhancement {
+  protect(): EnvelopConfigurationEnhancement<PluginContext> {
     return {
       plugins: [blockFieldSuggestionsPlugin(this.config.blockFieldSuggestion)],
     };

--- a/packages/graphql-armor/src/envelop/protections/cost-limit.ts
+++ b/packages/graphql-armor/src/envelop/protections/cost-limit.ts
@@ -2,7 +2,9 @@ import { costLimitPlugin } from '@escape.tech/graphql-armor-cost-limit';
 
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
-export class EnvelopCostLimitProtection extends EnvelopProtection {
+export class EnvelopCostLimitProtection<
+  PluginContext extends Record<string, any> = {},
+> extends EnvelopProtection<PluginContext> {
   get isEnabled(): boolean {
     if (!this.config.costLimit) {
       return this.enabledByDefault;
@@ -10,7 +12,7 @@ export class EnvelopCostLimitProtection extends EnvelopProtection {
     return this.config.costLimit.enabled ?? this.enabledByDefault;
   }
 
-  protect(): EnvelopConfigurationEnhancement {
+  protect(): EnvelopConfigurationEnhancement<PluginContext> {
     return {
       plugins: [costLimitPlugin(this.config.costLimit)],
     };

--- a/packages/graphql-armor/src/envelop/protections/max-aliases.ts
+++ b/packages/graphql-armor/src/envelop/protections/max-aliases.ts
@@ -2,7 +2,9 @@ import { maxAliasesPlugin } from '@escape.tech/graphql-armor-max-aliases';
 
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
-export class EnvelopMaxAliasesProtection extends EnvelopProtection {
+export class EnvelopMaxAliasesProtection<
+  PluginContext extends Record<string, any> = {},
+> extends EnvelopProtection<PluginContext> {
   get isEnabled(): boolean {
     if (!this.config.maxAliases) {
       return this.enabledByDefault;
@@ -10,7 +12,7 @@ export class EnvelopMaxAliasesProtection extends EnvelopProtection {
     return this.config.maxAliases.enabled ?? this.enabledByDefault;
   }
 
-  protect(): EnvelopConfigurationEnhancement {
+  protect(): EnvelopConfigurationEnhancement<PluginContext> {
     return {
       plugins: [maxAliasesPlugin(this.config.maxAliases)],
     };

--- a/packages/graphql-armor/src/envelop/protections/max-depth.ts
+++ b/packages/graphql-armor/src/envelop/protections/max-depth.ts
@@ -2,7 +2,9 @@ import { maxDepthPlugin } from '@escape.tech/graphql-armor-max-depth';
 
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
-export class EnvelopMaxDepthProtection extends EnvelopProtection {
+export class EnvelopMaxDepthProtection<
+  PluginContext extends Record<string, any> = {},
+> extends EnvelopProtection<PluginContext> {
   get isEnabled(): boolean {
     if (!this.config.maxDepth) {
       return this.enabledByDefault;
@@ -10,7 +12,7 @@ export class EnvelopMaxDepthProtection extends EnvelopProtection {
     return this.config.maxDepth.enabled ?? this.enabledByDefault;
   }
 
-  protect(): EnvelopConfigurationEnhancement {
+  protect(): EnvelopConfigurationEnhancement<PluginContext> {
     return {
       plugins: [maxDepthPlugin(this.config.maxDepth)],
     };

--- a/packages/graphql-armor/src/envelop/protections/max-directives.ts
+++ b/packages/graphql-armor/src/envelop/protections/max-directives.ts
@@ -2,7 +2,9 @@ import { maxDirectivesPlugin } from '@escape.tech/graphql-armor-max-directives';
 
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
-export class EnvelopMaxDirectivesProtection extends EnvelopProtection {
+export class EnvelopMaxDirectivesProtection<
+  PluginContext extends Record<string, any> = {},
+> extends EnvelopProtection<PluginContext> {
   get isEnabled(): boolean {
     if (!this.config.maxDirectives) {
       return this.enabledByDefault;
@@ -10,7 +12,7 @@ export class EnvelopMaxDirectivesProtection extends EnvelopProtection {
     return this.config.maxDirectives.enabled ?? this.enabledByDefault;
   }
 
-  protect(): EnvelopConfigurationEnhancement {
+  protect(): EnvelopConfigurationEnhancement<PluginContext> {
     return {
       plugins: [maxDirectivesPlugin(this.config.maxDirectives)],
     };

--- a/packages/graphql-armor/src/envelop/protections/max-tokens.ts
+++ b/packages/graphql-armor/src/envelop/protections/max-tokens.ts
@@ -2,7 +2,9 @@ import { maxTokensPlugin } from '@escape.tech/graphql-armor-max-tokens';
 
 import { EnvelopConfigurationEnhancement, EnvelopProtection } from './base-protection';
 
-export class EnvelopMaxTokensProtection extends EnvelopProtection {
+export class EnvelopMaxTokensProtection<
+  PluginContext extends Record<string, any> = {},
+> extends EnvelopProtection<PluginContext> {
   get isEnabled(): boolean {
     if (!this.config.maxTokens) {
       return this.enabledByDefault;
@@ -10,7 +12,7 @@ export class EnvelopMaxTokensProtection extends EnvelopProtection {
     return this.config.maxTokens.enabled ?? this.enabledByDefault;
   }
 
-  protect(): EnvelopConfigurationEnhancement {
+  protect(): EnvelopConfigurationEnhancement<PluginContext> {
     return {
       plugins: [maxTokensPlugin(this.config.maxTokens)],
     };

--- a/packages/graphql-armor/test/envelop/armor.spec.ts
+++ b/packages/graphql-armor/test/envelop/armor.spec.ts
@@ -1,8 +1,13 @@
+import type { Plugin } from '@envelop/types';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { describe, expect, it } from '@jest/globals';
 
 import { EnvelopArmor, EnvelopArmorPlugin } from '../../src/envelop/armor';
+
+// test checking if the plugin inherits the context correctly
+const _test_0: Plugin = EnvelopArmorPlugin();
+const _test_1: Plugin<{ my: 'ctx' }> = EnvelopArmorPlugin();
 
 describe('envelopArmor', () => {
   const envelop = new EnvelopArmor();

--- a/packages/plugins/block-field-suggestions/src/index.ts
+++ b/packages/plugins/block-field-suggestions/src/index.ts
@@ -13,7 +13,9 @@ const formatter = (error: GraphQLError, mask: string): GraphQLError => {
   return error as GraphQLError;
 };
 
-const blockFieldSuggestionsPlugin = (options?: BlockFieldSuggestionsOptions): Plugin => {
+const blockFieldSuggestionsPlugin = <PluginContext extends Record<string, any> = {}>(
+  options?: BlockFieldSuggestionsOptions,
+): Plugin<PluginContext> => {
   const mask = options?.mask ?? blockFieldSuggestionsDefaultOptions.mask;
 
   return {

--- a/packages/plugins/block-field-suggestions/test/index.spec.ts
+++ b/packages/plugins/block-field-suggestions/test/index.spec.ts
@@ -1,8 +1,13 @@
+import type { Plugin } from '@envelop/types';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { describe, expect, it } from '@jest/globals';
 
 import { blockFieldSuggestionsPlugin } from '../src/index';
+
+// test checking if the plugin inherits the context correctly
+const _test_0: Plugin = blockFieldSuggestionsPlugin();
+const _test_1: Plugin<{ my: 'ctx' }> = blockFieldSuggestionsPlugin();
 
 const typeDefinitions = `
   type Book {

--- a/packages/plugins/character-limit/src/index.ts
+++ b/packages/plugins/character-limit/src/index.ts
@@ -50,7 +50,9 @@ export const ApolloServerCharacterLimitPlugin = function (options?: CharacterLim
   };
 };
 
-export const characterLimitPlugin = (options?: CharacterLimitOptions): Plugin => {
+export const characterLimitPlugin = <PluginContext extends Record<string, any> = {}>(
+  options?: CharacterLimitOptions,
+): Plugin<PluginContext> => {
   const config = Object.assign(
     {},
     characterLimitDefaultOptions,

--- a/packages/plugins/character-limit/test/index.spec.ts
+++ b/packages/plugins/character-limit/test/index.spec.ts
@@ -1,8 +1,13 @@
+import type { Plugin } from '@envelop/types';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { describe, expect, it } from '@jest/globals';
 
 import { characterLimitPlugin } from '../src/index';
+
+// test checking if the plugin inherits the context correctly
+const _test_0: Plugin = characterLimitPlugin();
+const _test_1: Plugin<{ my: 'ctx' }> = characterLimitPlugin();
 
 const typeDefinitions = `
   type Book {

--- a/packages/plugins/cost-limit/src/index.ts
+++ b/packages/plugins/cost-limit/src/index.ts
@@ -140,7 +140,9 @@ class CostLimitVisitor {
 export const costLimitRule = (options?: CostLimitOptions) => (context: ValidationContext) =>
   new CostLimitVisitor(context, options);
 
-export const costLimitPlugin = (options?: CostLimitOptions): Plugin => {
+export const costLimitPlugin = <PluginContext extends Record<string, any> = {}>(
+  options?: CostLimitOptions,
+): Plugin<PluginContext> => {
   return {
     onValidate({ addValidationRule }: any) {
       addValidationRule(costLimitRule(options));

--- a/packages/plugins/cost-limit/test/index.spec.ts
+++ b/packages/plugins/cost-limit/test/index.spec.ts
@@ -1,9 +1,14 @@
+import type { Plugin } from '@envelop/types';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { describe, expect, it } from '@jest/globals';
 import { getIntrospectionQuery } from 'graphql';
 
 import { costLimitPlugin } from '../src/index';
+
+// test checking if the plugin inherits the context correctly
+const _test_0: Plugin = costLimitPlugin();
+const _test_1: Plugin<{ my: 'ctx' }> = costLimitPlugin();
 
 const typeDefinitions = `
   type Book {

--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -109,7 +109,9 @@ class MaxAliasesVisitor {
 const maxAliasesRule = (options?: MaxAliasesOptions) => (context: ValidationContext) =>
   new MaxAliasesVisitor(context, options);
 
-const maxAliasesPlugin = (options?: MaxAliasesOptions): Plugin => {
+const maxAliasesPlugin = <PluginContext extends Record<string, any> = {}>(
+  options?: MaxAliasesOptions,
+): Plugin<PluginContext> => {
   return {
     onValidate({ addValidationRule }: any) {
       addValidationRule(maxAliasesRule(options));

--- a/packages/plugins/max-aliases/test/index.spec.ts
+++ b/packages/plugins/max-aliases/test/index.spec.ts
@@ -1,9 +1,14 @@
+import type { Plugin } from '@envelop/types';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { describe, expect, it } from '@jest/globals';
 import { jest } from '@jest/globals';
 
 import { maxAliasesPlugin } from '../src/index';
+
+// test checking if the plugin inherits the context correctly
+const _test_0: Plugin = maxAliasesPlugin();
+const _test_1: Plugin<{ my: 'ctx' }> = maxAliasesPlugin();
 
 const typeDefinitions = `
   type Book {

--- a/packages/plugins/max-depth/src/index.ts
+++ b/packages/plugins/max-depth/src/index.ts
@@ -119,7 +119,9 @@ class MaxDepthVisitor {
 export const maxDepthRule = (options?: MaxDepthOptions) => (context: ValidationContext) =>
   new MaxDepthVisitor(context, options);
 
-export const maxDepthPlugin = (options?: MaxDepthOptions): Plugin => {
+export const maxDepthPlugin = <PluginContext extends Record<string, any> = {}>(
+  options?: MaxDepthOptions,
+): Plugin<PluginContext> => {
   return {
     onValidate({ addValidationRule }: any) {
       addValidationRule(maxDepthRule(options));

--- a/packages/plugins/max-depth/test/index.spec.ts
+++ b/packages/plugins/max-depth/test/index.spec.ts
@@ -1,9 +1,14 @@
+import type { Plugin } from '@envelop/types';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { describe, expect, it } from '@jest/globals';
 import { getIntrospectionQuery } from 'graphql';
 
 import { maxDepthPlugin } from '../src/index';
+
+// test checking if the plugin inherits the context correctly
+const _test_0: Plugin = maxDepthPlugin();
+const _test_1: Plugin<{ my: 'ctx' }> = maxDepthPlugin();
 
 const typeDefinitions = `
   type Author {

--- a/packages/plugins/max-directives/src/index.ts
+++ b/packages/plugins/max-directives/src/index.ts
@@ -102,7 +102,9 @@ class MaxDirectivesVisitor {
 export const maxDirectivesRule = (options?: MaxDirectivesOptions) => (context: ValidationContext) =>
   new MaxDirectivesVisitor(context, options);
 
-export const maxDirectivesPlugin = (options?: MaxDirectivesOptions): Plugin => {
+export const maxDirectivesPlugin = <PluginContext extends Record<string, any> = {}>(
+  options?: MaxDirectivesOptions,
+): Plugin<PluginContext> => {
   return {
     onValidate({ addValidationRule }: any) {
       addValidationRule(maxDirectivesRule(options));

--- a/packages/plugins/max-directives/test/index.spec.ts
+++ b/packages/plugins/max-directives/test/index.spec.ts
@@ -1,9 +1,14 @@
+import type { Plugin } from '@envelop/types';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { describe, expect, it } from '@jest/globals';
 import { jest } from '@jest/globals';
 
 import { maxDirectivesPlugin } from '../src/index';
+
+// test checking if the plugin inherits the context correctly
+const _test_0: Plugin = maxDirectivesPlugin();
+const _test_1: Plugin<{ my: 'ctx' }> = maxDirectivesPlugin();
 
 const typeDefinitions = `
   type Book {

--- a/packages/plugins/max-tokens/src/index.ts
+++ b/packages/plugins/max-tokens/src/index.ts
@@ -78,7 +78,9 @@ export class MaxTokensParserWLexer extends Parser {
   }
 }
 
-export function maxTokensPlugin(config?: MaxTokensOptions): Plugin {
+export function maxTokensPlugin<PluginContext extends Record<string, any> = {}>(
+  config?: MaxTokensOptions,
+): Plugin<PluginContext> {
   function parseWithTokenLimit(source: string | Source, options?: ParseOptions) {
     // @ts-expect-error TODO(@c3b5aw): address the type issue
     const parser = new MaxTokensParserWLexer(source, Object.assign({}, options, config));

--- a/packages/plugins/max-tokens/test/index.spec.ts
+++ b/packages/plugins/max-tokens/test/index.spec.ts
@@ -1,8 +1,13 @@
+import type { Plugin } from '@envelop/types';
 import { assertSingleExecutionValue, createTestkit } from '@envelop/testing';
 import { describe, expect, it, jest } from '@jest/globals';
 import { buildSchema } from 'graphql';
 
 import { maxTokenDefaultOptions, maxTokensPlugin } from '../src/index';
+
+// test checking if the plugin inherits the context correctly
+const _test_0: Plugin = maxTokensPlugin();
+const _test_1: Plugin<{ my: 'ctx' }> = maxTokensPlugin();
 
 const schema = buildSchema(/* GraphQL */ `
   type Query {


### PR DESCRIPTION
envelop dependants might have custom requirements for the context, like graphql-yoga and @graphql-hive/gateway does. It is important that each of the plugins inherit that context, otherwise typechecking will fail.

I've added tests to each of the packages spec; **however,** these are not typechecked. I didn't want to change anything regarding the project setup in case the changes get rejected. These tests are not a blocker, but are important still.