### PR TITLE
fix: max-depth ignore only Field Node named __schema

### DIFF
--- a/packages/plugins/max-depth/src/index.ts
+++ b/packages/plugins/max-depth/src/index.ts
@@ -76,7 +76,12 @@ class MaxDepthVisitor {
     node: FieldNode | FragmentDefinitionNode | InlineFragmentNode | OperationDefinitionNode | FragmentSpreadNode,
     parentDepth = 0,
   ): number {
-    if (this.config.ignoreIntrospection && 'name' in node && node.name?.value === '__schema') {
+    if (
+      this.config.ignoreIntrospection &&
+      'name' in node &&
+      node.name?.value === '__schema' &&
+      node.kind === Kind.FIELD
+    ) {
       return 0;
     }
     let depth = parentDepth;

--- a/packages/plugins/max-depth/test/index.spec.ts
+++ b/packages/plugins/max-depth/test/index.spec.ts
@@ -234,4 +234,34 @@ describe('maxDepthPlugin', () => {
       `Syntax Error: Query depth limit of ${maxDepth} exceeded, found ${maxDepth + 1}.`,
     ]);
   });
+
+  it('rejects for fragment named `__schema` exceeding max depth', async () => {
+    const bypass_query = `
+      query {
+        books {
+          author {
+            books {
+              author {
+                ...__schema
+              }
+            }
+          }
+        }
+      }
+      fragment __schema on Author {
+        books {
+          title
+        }
+      }
+    `;
+    const maxDepth = 6;
+    const testkit = createTestkit([maxDepthPlugin({ n: maxDepth, exposeLimits: true })], schema);
+    const result = await testkit.execute(bypass_query);
+
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      `Syntax Error: Query depth limit of ${maxDepth} exceeded, found ${maxDepth + 2}.`,
+    ]);
+  });
 });


### PR DESCRIPTION
Similar to [772](https://github.com/Escape-Technologies/graphql-armor/pull/772), this is for max-depth plugin.

This PR fixes a bypass to the cost-limit plugin (in default settings) by skipping only nodes of type `Field` when `ignoreIntrospection` is set.

This will fix the following bypass:

```gql
query {
  books {
    author {
      books {
        author {
          ...__schema
        }
      }
    }
  }
}
fragment __schema on Author {
  books {
    title
  }
}
```
