### PR TITLE
Added JSDoc & missing fields on the doc pages

### DIFF
--- a/.changeset/few-suits-jump.md
+++ b/.changeset/few-suits-jump.md
@@ -1,0 +1,12 @@
+---
+'@escape.tech/graphql-armor-block-field-suggestions': patch
+'@escape.tech/graphql-armor-character-limit': patch
+'@escape.tech/graphql-armor-max-directives': patch
+'@escape.tech/graphql-armor-max-aliases': patch
+'@escape.tech/graphql-armor-cost-limit': patch
+'@escape.tech/graphql-armor-max-tokens': patch
+'@escape.tech/graphql-armor-max-depth': patch
+'@escape.tech/graphql-armor-types': patch
+---
+
+Documented plugin configuration type with JSDoc

--- a/packages/plugins/block-field-suggestions/src/index.ts
+++ b/packages/plugins/block-field-suggestions/src/index.ts
@@ -1,7 +1,13 @@
 import type { Plugin } from '@envelop/core';
 import { GraphQLError } from 'graphql';
 
-type BlockFieldSuggestionsOptions = { mask?: string };
+type BlockFieldSuggestionsOptions = {
+  /**
+   * Mask applied to the error message.
+   * @default '[Suggestion hidden]'
+   */
+  mask?: string;
+};
 const blockFieldSuggestionsDefaultOptions: Required<BlockFieldSuggestionsOptions> = {
   mask: '[Suggestion hidden]',
 };
@@ -13,6 +19,13 @@ const formatter = (error: GraphQLError, mask: string): GraphQLError => {
   return error as GraphQLError;
 };
 
+/**
+ * Prevent returning field suggestions and leaking your schema to unauthorized actors.
+ *
+ * In production, this can lead to Schema leak even if the introspection is disabled.
+ *
+ * Use with `@envelop/core` from `@the-guild-org`.
+ */
 const blockFieldSuggestionsPlugin = <PluginContext extends Record<string, any> = {}>(
   options?: BlockFieldSuggestionsOptions,
 ): Plugin<PluginContext> => {

--- a/packages/plugins/character-limit/src/index.ts
+++ b/packages/plugins/character-limit/src/index.ts
@@ -16,7 +16,7 @@ export type CharacterLimitOptions = {
    */
   exposeLimits?: boolean;
   /**
-   * The error message used when {@link CharacterLimitOptions.exposeLimits} is set to `true`.
+   * The error message used when {@link CharacterLimitOptions.exposeLimits} is set to `false`.
    * @default 'Query validation error.'
    */
   errorMessage?: string;

--- a/packages/plugins/character-limit/src/index.ts
+++ b/packages/plugins/character-limit/src/index.ts
@@ -3,8 +3,22 @@ import type { GraphQLArmorCallbackConfiguration } from '@escape.tech/graphql-arm
 import { GraphQLError } from 'graphql';
 
 export type CharacterLimitOptions = {
+  /**
+   * Number of characters allowed.
+   * @default 15000
+   */
   maxLength?: number;
+  /**
+   * If this is set to `true`, details about the configured limit are included in the GraphQLError message when errors occur.
+   *
+   * When set to `false` {@link CharacterLimitOptions.errorMessage} is used as the GraphQLError message.
+   * @default true
+   */
   exposeLimits?: boolean;
+  /**
+   * The error message used when {@link CharacterLimitOptions.exposeLimits} is set to `true`.
+   * @default 'Query validation error.'
+   */
   errorMessage?: string;
 } & GraphQLArmorCallbackConfiguration;
 
@@ -17,7 +31,13 @@ export const characterLimitDefaultOptions: Required<CharacterLimitOptions> = {
   propagateOnRejection: true,
 };
 
-/* CharacterLimitPlugin Supports Apollo Server v3 and v4 */
+/**
+ * Limit number of characters in a GraphQL query document.
+ *
+ * This help preventing DoS attacks by hard-limiting the size of the query document.
+ *
+ * ApolloServerCharacterLimitPlugin Supports Apollo Server v3 and v4.
+ */
 export const ApolloServerCharacterLimitPlugin = function (options?: CharacterLimitOptions): any {
   const config = Object.assign(
     {},
@@ -50,6 +70,13 @@ export const ApolloServerCharacterLimitPlugin = function (options?: CharacterLim
   };
 };
 
+/**
+ * Limit number of characters in a GraphQL query document.
+ *
+ * This help preventing DoS attacks by hard-limiting the size of the query document.
+ *
+ * Use with `@envelop/core` from `@the-guild-org`.
+ */
 export const characterLimitPlugin = <PluginContext extends Record<string, any> = {}>(
   options?: CharacterLimitOptions,
 ): Plugin<PluginContext> => {

--- a/packages/plugins/cost-limit/src/index.ts
+++ b/packages/plugins/cost-limit/src/index.ts
@@ -12,14 +12,52 @@ import {
 } from 'graphql';
 
 export type CostLimitOptions = {
+  /**
+   * Cost allowed.
+   * @default 5000
+   */
   maxCost?: number;
+  /**
+   * Static cost of an object.
+   * @default 2
+   */
   objectCost?: number;
+  /**
+   * Static cost of a field.
+   * @default 1
+   */
   scalarCost?: number;
+  /**
+   * Factorial applied to nested operator.
+   * @default 1.5
+   */
   depthCostFactor?: number;
+  /**
+   * Flatten frament spreads and inline framents for the cost calculation.
+   * @default false
+   */
   flattenFragments?: boolean;
+  /**
+   * Ignore the cost of introspection queries.
+   * @default true
+   */
   ignoreIntrospection?: boolean;
+  /**
+   * @deprecated No longer has any effect on the computed cost. Use {@link CostLimitOptions.depthCostFactor} instead.
+   * @default 1000
+   */
   fragmentRecursionCost?: number;
+  /**
+   * If this is set to `true`, details about the configured limit are included in the GraphQLError message when errors occur.
+   *
+   * When set to `false` {@link CostLimitOptions.errorMessage} is used as the GraphQLError message.
+   * @default true
+   */
   exposeLimits?: boolean;
+  /**
+   * The error message used when {@link CostLimitOptions.exposeLimits} is set to `true`.
+   * @default 'Query validation error.'
+   */
   errorMessage?: string;
 } & GraphQLArmorCallbackConfiguration;
 
@@ -153,9 +191,19 @@ class CostLimitVisitor {
   }
 }
 
+/**
+ * Limit the complexity of a GraphQL document.
+ *
+ * Use with `@graphql/graphql-js`.
+ */
 export const costLimitRule = (options?: CostLimitOptions) => (context: ValidationContext) =>
   new CostLimitVisitor(context, options);
 
+/**
+ * Limit the complexity of a GraphQL document.
+ *
+ * Use with `@envelop/core` from `@the-guild-org`.
+ */
 export const costLimitPlugin = <PluginContext extends Record<string, any> = {}>(
   options?: CostLimitOptions,
 ): Plugin<PluginContext> => {

--- a/packages/plugins/cost-limit/src/index.ts
+++ b/packages/plugins/cost-limit/src/index.ts
@@ -55,7 +55,7 @@ export type CostLimitOptions = {
    */
   exposeLimits?: boolean;
   /**
-   * The error message used when {@link CostLimitOptions.exposeLimits} is set to `true`.
+   * The error message used when {@link CostLimitOptions.exposeLimits} is set to `false`.
    * @default 'Query validation error.'
    */
   errorMessage?: string;

--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -12,9 +12,27 @@ import {
 } from 'graphql';
 
 type MaxAliasesOptions = {
+  /**
+   * Aliases threshold.
+   * @default 15
+   */
   n?: number;
+  /**
+   * List of queries that are allowed to bypass the plugin.
+   * @default ['__typename']
+   */
   allowList?: string[];
+  /**
+   * If this is set to `true`, details about the configured limit are included in the GraphQLError message when errors occur.
+   *
+   * When set to `false` {@link MaxAliasesOptions.errorMessage} is used as the GraphQLError message.
+   * @default true
+   */
   exposeLimits?: boolean;
+  /**
+   * The error message used when {@link MaxAliasesOptions.exposeLimits} is set to `true`.
+   * @default 'Query validation error.'
+   */
   errorMessage?: string;
 } & GraphQLArmorCallbackConfiguration;
 
@@ -106,9 +124,23 @@ class MaxAliasesVisitor {
   }
 }
 
+/**
+ * Limit the number of aliases in a GraphQL document.
+ *
+ * It is used to prevent DOS attack or heap overflow.
+ *
+ * Use with `@graphql/graphql-js`.
+ */
 const maxAliasesRule = (options?: MaxAliasesOptions) => (context: ValidationContext) =>
   new MaxAliasesVisitor(context, options);
 
+/**
+ * Limit the number of aliases in a GraphQL document.
+ *
+ * It is used to prevent DOS attack or heap overflow.
+ *
+ * Use with `@envelop/core` from `@the-guild-org`.
+ */
 const maxAliasesPlugin = <PluginContext extends Record<string, any> = {}>(
   options?: MaxAliasesOptions,
 ): Plugin<PluginContext> => {

--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -30,7 +30,7 @@ type MaxAliasesOptions = {
    */
   exposeLimits?: boolean;
   /**
-   * The error message used when {@link MaxAliasesOptions.exposeLimits} is set to `true`.
+   * The error message used when {@link MaxAliasesOptions.exposeLimits} is set to `false`.
    * @default 'Query validation error.'
    */
   errorMessage?: string;

--- a/packages/plugins/max-aliases/src/index.ts
+++ b/packages/plugins/max-aliases/src/index.ts
@@ -18,7 +18,7 @@ type MaxAliasesOptions = {
    */
   n?: number;
   /**
-   * List of queries that are allowed to bypass the plugin.
+   * List of queries and alias names that are allowed to bypass the plugin.
    * @default ['__typename']
    */
   allowList?: string[];

--- a/packages/plugins/max-depth/src/index.ts
+++ b/packages/plugins/max-depth/src/index.ts
@@ -35,7 +35,7 @@ export type MaxDepthOptions = {
    */
   exposeLimits?: boolean;
   /**
-   * The error message used when {@link MaxDepthOptions.exposeLimits} is set to `true`.
+   * The error message used when {@link MaxDepthOptions.exposeLimits} is set to `false`.
    * @default 'Query validation error.'
    */
   errorMessage?: string;

--- a/packages/plugins/max-depth/src/index.ts
+++ b/packages/plugins/max-depth/src/index.ts
@@ -12,10 +12,32 @@ import {
 } from 'graphql';
 
 export type MaxDepthOptions = {
+  /**
+   * Depth threshold.
+   * @default 6
+   */
   n?: number;
+  /**
+   * Ignore the depth of introspection queries.
+   * @default true
+   */
   ignoreIntrospection?: boolean;
+  /**
+   * Flatten frament spreads and inline framents for the depth count.
+   * @default false
+   */
   flattenFragments?: boolean;
+  /**
+   * If this is set to `true`, details about the configured limit are included in the GraphQLError message when errors occur.
+   *
+   * When set to `false` {@link MaxDepthOptions.errorMessage} is used as the GraphQLError message.
+   * @default true
+   */
   exposeLimits?: boolean;
+  /**
+   * The error message used when {@link MaxDepthOptions.exposeLimits} is set to `true`.
+   * @default 'Query validation error.'
+   */
   errorMessage?: string;
 } & GraphQLArmorCallbackConfiguration;
 const maxDepthDefaultOptions: Required<MaxDepthOptions> = {
@@ -121,9 +143,23 @@ class MaxDepthVisitor {
   }
 }
 
+/**
+ * Limit the depth of a GraphQL document.
+ *
+ * It is used to prevent too large queries that could lead to overfetching or DOS attack.
+ *
+ * Use with `@graphql/graphql-js`.
+ */
 export const maxDepthRule = (options?: MaxDepthOptions) => (context: ValidationContext) =>
   new MaxDepthVisitor(context, options);
 
+/**
+ * Limit the depth of a GraphQL document.
+ *
+ * It is used to prevent too large queries that could lead to overfetching or DOS attack.
+ *
+ * Use with `@envelop/core` from `@the-guild-org`.
+ */
 export const maxDepthPlugin = <PluginContext extends Record<string, any> = {}>(
   options?: MaxDepthOptions,
 ): Plugin<PluginContext> => {

--- a/packages/plugins/max-directives/src/index.ts
+++ b/packages/plugins/max-directives/src/index.ts
@@ -25,7 +25,7 @@ export type MaxDirectivesOptions = {
    */
   exposeLimits?: boolean;
   /**
-   * The error message used when {@link MaxDirectivesOptions.exposeLimits} is set to `true`.
+   * The error message used when {@link MaxDirectivesOptions.exposeLimits} is set to `false`.
    * @default 'Query validation error.'
    */
   errorMessage?: string;

--- a/packages/plugins/max-directives/src/index.ts
+++ b/packages/plugins/max-directives/src/index.ts
@@ -12,8 +12,22 @@ import {
 } from 'graphql';
 
 export type MaxDirectivesOptions = {
+  /**
+   * Directives threshold.
+   * @default 50
+   */
   n?: number;
+  /**
+   * If this is set to `true`, details about the configured limit are included in the GraphQLError message when errors occur.
+   *
+   * When set to `false` {@link MaxDirectivesOptions.errorMessage} is used as the GraphQLError message.
+   * @default true
+   */
   exposeLimits?: boolean;
+  /**
+   * The error message used when {@link MaxDirectivesOptions.exposeLimits} is set to `true`.
+   * @default 'Query validation error.'
+   */
   errorMessage?: string;
 } & GraphQLArmorCallbackConfiguration;
 
@@ -99,9 +113,23 @@ class MaxDirectivesVisitor {
   }
 }
 
+/**
+ * Limit the number of directives in a GraphQL document.
+ *
+ * It is used to prevent DOS attack, heap overflow or server overloading.
+ *
+ * Use with `@graphql/graphql-js`.
+ */
 export const maxDirectivesRule = (options?: MaxDirectivesOptions) => (context: ValidationContext) =>
   new MaxDirectivesVisitor(context, options);
 
+/**
+ * Limit the number of directives in a GraphQL document.
+ *
+ * It is used to prevent DOS attack, heap overflow or server overloading.
+ *
+ * Use with `@envelop/core` from `@the-guild-org`.
+ */
 export const maxDirectivesPlugin = <PluginContext extends Record<string, any> = {}>(
   options?: MaxDirectivesOptions,
 ): Plugin<PluginContext> => {

--- a/packages/plugins/max-tokens/src/index.ts
+++ b/packages/plugins/max-tokens/src/index.ts
@@ -10,8 +10,22 @@ type maxTokensParserWLexerOptions = ParseOptions & {
 } & GraphQLArmorCallbackConfiguration;
 
 export type MaxTokensOptions = {
+  /**
+   * Tokens threshold.
+   * @default 1000
+   */
   n?: number;
+  /**
+   * If this is set to `true`, details about the configured limit are included in the GraphQLError message when errors occur.
+   *
+   * When set to `false` {@link MaxTokensOptions.errorMessage} is used as the GraphQLError message.
+   * @default true
+   */
   exposeLimits?: boolean;
+  /**
+   * The error message used when {@link MaxTokensOptions.exposeLimits} is set to `true`.
+   * @default 'Query validation error.'
+   */
   errorMessage?: string;
 } & GraphQLArmorCallbackConfiguration;
 
@@ -78,6 +92,15 @@ export class MaxTokensParserWLexer extends Parser {
   }
 }
 
+/**
+ * Limit the number of tokens in a GraphQL document.
+ *
+ * It is used to prevent DOS attack, heap overflow or server overloading.
+ *
+ * The token limit is often limited by the graphql parser, but this is not always the case and would lead to a fatal heap overflow.
+ *
+ * Use with `@envelop/core` from `@the-guild-org`.
+ */
 export function maxTokensPlugin<PluginContext extends Record<string, any> = {}>(
   config?: MaxTokensOptions,
 ): Plugin<PluginContext> {

--- a/packages/plugins/max-tokens/src/index.ts
+++ b/packages/plugins/max-tokens/src/index.ts
@@ -23,7 +23,7 @@ export type MaxTokensOptions = {
    */
   exposeLimits?: boolean;
   /**
-   * The error message used when {@link MaxTokensOptions.exposeLimits} is set to `true`.
+   * The error message used when {@link MaxTokensOptions.exposeLimits} is set to `false`.
    * @default 'Query validation error.'
    */
   errorMessage?: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -7,22 +7,65 @@ import type { MaxTokensOptions } from '@escape.tech/graphql-armor-max-tokens';
 import type { GraphQLError, ValidationContext } from 'graphql';
 
 export type ProtectionConfiguration = {
+  /**
+   * Toggle the plugin.
+   */
   enabled?: boolean;
 };
 
 export type GraphQLArmorConfig = {
+  /**
+   * Prevent returning field suggestions and leaking your schema to unauthorized actors.
+   *
+   * In production, this can lead to Schema leak even if the introspection is disabled.
+   */
   blockFieldSuggestion?: ProtectionConfiguration & BlockFieldSuggestionsOptions;
+  /**
+   * Limit the complexity of a GraphQL document.
+   */
   costLimit?: ProtectionConfiguration & CostLimitOptions;
+  /**
+   * Limit the number of aliases in a GraphQL document.
+   *
+   * It is used to prevent DOS attack or heap overflow.
+   */
   maxAliases?: ProtectionConfiguration & MaxAliasesOptions;
+  /**
+   * Limit the depth of a GraphQL document.
+   *
+   * It is used to prevent too large queries that could lead to overfetching or DOS attack.
+   */
   maxDepth?: ProtectionConfiguration & MaxDepthOptions;
+  /**
+   * Limit the number of directives in a GraphQL document.
+   *
+   * It is used to prevent DOS attack, heap overflow or server overloading.
+   */
   maxDirectives?: ProtectionConfiguration & MaxDirectivesOptions;
+  /**
+   * Limit the number of tokens in a GraphQL document.
+   *
+   * It is used to prevent DOS attack, heap overflow or server overloading.
+   *
+   * The token limit is often limited by the graphql parser, but this is not always the case and would lead to a fatal heap overflow.
+   */
   maxTokens?: ProtectionConfiguration & MaxTokensOptions;
 };
 
 export type GraphQLArmorAcceptCallback = (ctx: ValidationContext | null, details: any) => void;
 export type GraphQLArmorRejectCallback = (ctx: ValidationContext | null, error: GraphQLError) => void;
 export type GraphQLArmorCallbackConfiguration = {
+  /**
+   * Callbacks that are ran whenever a Query is accepted.
+   */
   onAccept?: GraphQLArmorAcceptCallback[];
+  /**
+   * Callbacks that are ran whenever a Query is rejected.
+   */
   onReject?: GraphQLArmorRejectCallback[];
+  /**
+   * Do you want to propagate the rejection to the client?
+   * @default true
+   */
   propagateOnRejection?: boolean;
 };

--- a/services/docs/docs/plugins/character-limit.md
+++ b/services/docs/docs/plugins/character-limit.md
@@ -35,7 +35,9 @@ const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
     characterLimitPlugin({
-        maxLength: 15000, // Number of characters allowed | Default: 15000
+        maxLength: 15000,                        // Number of characters allowed | Default: 15000
+        exposeLimits: true,                      // Default: true
+        errorMessage: 'Query validation error.', // Default: 'Query validation error.'
     }),
   ]
 });

--- a/services/docs/docs/plugins/cost-limit.md
+++ b/services/docs/docs/plugins/cost-limit.md
@@ -42,7 +42,7 @@ GraphQLArmorConfig({
     */
     exposeLimits?: boolean,
 
-    // The error message used when exposeLimits is set to true | default: 'Query validation error.'
+    // The error message used when exposeLimits is set to false | default: 'Query validation error.'
     errorMessage?: string,
 
     // Callbacks that are ran whenever a Query is accepted

--- a/services/docs/docs/plugins/cost-limit.md
+++ b/services/docs/docs/plugins/cost-limit.md
@@ -34,6 +34,17 @@ GraphQLArmorConfig({
     // Ignore the cost of introspection queries | default: true
     ignoreIntrospection?: boolean,
 
+    /* 
+      If this is set to true, details about the configured limit are included in the GraphQLError message when errors occur.
+      When set to false errorMessage is used as the GraphQLError message.
+
+      default: true
+    */
+    exposeLimits?: boolean,
+
+    // The error message used when exposeLimits is set to true | default: 'Query validation error.'
+    errorMessage?: string,
+
     // Callbacks that are ran whenever a Query is accepted
     onAccept?: GraphQLArmorAcceptCallback[],
 

--- a/services/docs/docs/plugins/max-aliases.md
+++ b/services/docs/docs/plugins/max-aliases.md
@@ -29,7 +29,7 @@ GraphQLArmorConfig({
     */
     exposeLimits?: boolean,
 
-    // The error message used when exposeLimits is set to true | default: 'Query validation error.'
+    // The error message used when exposeLimits is set to false | default: 'Query validation error.'
     errorMessage?: string,
 
     // Callbacks that are ran whenever a Query is accepted

--- a/services/docs/docs/plugins/max-aliases.md
+++ b/services/docs/docs/plugins/max-aliases.md
@@ -41,7 +41,7 @@ GraphQLArmorConfig({
     // Do you want to propagate the rejection to the client? | default: true
     propagateOnRejection?: boolean,
 
-    // List of queries that are allowed to bypass the plugin | default: ['__typename']
+    // List of queries and alias names that are allowed to bypass the plugin | default: ['__typename']
     allowList?: string[],
   }
 })

--- a/services/docs/docs/plugins/max-aliases.md
+++ b/services/docs/docs/plugins/max-aliases.md
@@ -21,6 +21,17 @@ GraphQLArmorConfig({
     // Aliases threshold | default: 15
     n?: int,
 
+    /* 
+      If this is set to true, details about the configured limit are included in the GraphQLError message when errors occur.
+      When set to false errorMessage is used as the GraphQLError message.
+
+      default: true
+    */
+    exposeLimits?: boolean,
+
+    // The error message used when exposeLimits is set to true | default: 'Query validation error.'
+    errorMessage?: string,
+
     // Callbacks that are ran whenever a Query is accepted
     onAccept?: GraphQLArmorAcceptCallback[],
 

--- a/services/docs/docs/plugins/max-depth.md
+++ b/services/docs/docs/plugins/max-depth.md
@@ -28,6 +28,17 @@ GraphQLArmorConfig({
     // Flatten frament spreads and inline framents for the depth count | default: false
     flattenFragments?: boolean,
 
+    /* 
+      If this is set to true, details about the configured limit are included in the GraphQLError message when errors occur.
+      When set to false errorMessage is used as the GraphQLError message.
+
+      default: true
+    */
+    exposeLimits?: boolean,
+
+    // The error message used when exposeLimits is set to true | default: 'Query validation error.'
+    errorMessage?: string,
+
     // Callbacks that are ran whenever a Query is accepted
     onAccept?: GraphQLArmorAcceptCallback[],
 

--- a/services/docs/docs/plugins/max-depth.md
+++ b/services/docs/docs/plugins/max-depth.md
@@ -36,7 +36,7 @@ GraphQLArmorConfig({
     */
     exposeLimits?: boolean,
 
-    // The error message used when exposeLimits is set to true | default: 'Query validation error.'
+    // The error message used when exposeLimits is set to false | default: 'Query validation error.'
     errorMessage?: string,
 
     // Callbacks that are ran whenever a Query is accepted

--- a/services/docs/docs/plugins/max-directives.md
+++ b/services/docs/docs/plugins/max-directives.md
@@ -30,7 +30,7 @@ GraphQLArmorConfig({
     */
     exposeLimits?: boolean,
 
-    // The error message used when exposeLimits is set to true | default: 'Query validation error.'
+    // The error message used when exposeLimits is set to false | default: 'Query validation error.'
     errorMessage?: string,
 
     // Callbacks that are ran whenever a Query is accepted

--- a/services/docs/docs/plugins/max-directives.md
+++ b/services/docs/docs/plugins/max-directives.md
@@ -22,6 +22,17 @@ GraphQLArmorConfig({
     // Directives threshold | default: 50
     n?: int,
 
+    /* 
+      If this is set to true, details about the configured limit are included in the GraphQLError message when errors occur.
+      When set to false errorMessage is used as the GraphQLError message.
+
+      default: true
+    */
+    exposeLimits?: boolean,
+
+    // The error message used when exposeLimits is set to true | default: 'Query validation error.'
+    errorMessage?: string,
+
     // Callbacks that are ran whenever a Query is accepted
     onAccept?: GraphQLArmorAcceptCallback[],
 

--- a/services/docs/docs/plugins/max-tokens.md
+++ b/services/docs/docs/plugins/max-tokens.md
@@ -32,7 +32,7 @@ GraphQLArmorConfig({
     */
     exposeLimits?: boolean,
 
-    // The error message used when exposeLimits is set to true | default: 'Query validation error.'
+    // The error message used when exposeLimits is set to false | default: 'Query validation error.'
     errorMessage?: string,
 
     // Callbacks that are ran whenever a Query is accepted

--- a/services/docs/docs/plugins/max-tokens.md
+++ b/services/docs/docs/plugins/max-tokens.md
@@ -24,6 +24,17 @@ GraphQLArmorConfig({
     // Tokens threshold | default: 1000
     n?: int,
 
+    /* 
+      If this is set to true, details about the configured limit are included in the GraphQLError message when errors occur.
+      When set to false errorMessage is used as the GraphQLError message.
+
+      default: true
+    */
+    exposeLimits?: boolean,
+
+    // The error message used when exposeLimits is set to true | default: 'Query validation error.'
+    errorMessage?: string,
+
     // Callbacks that are ran whenever a Query is accepted
     onAccept?: GraphQLArmorAcceptCallback[],
 


### PR DESCRIPTION
This PR add a certain amount of JSDoc on every plugins.

It also document both the `exposeLimits` and `errorMessage` fields on the website.