### PR TITLE
chore(deps): use @as-integrations/express4 for @apollo/server v^5

### DIFF
--- a/examples/apollo/package.json
+++ b/examples/apollo/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@apollo/gateway": "2.11.0",
     "@apollo/server": "^5.2.0",
+    "@as-integrations/express4": "^1.1.2",
     "@escape.tech/graphql-armor": "*",
     "body-parser": "^2.2.0",
     "express": "5.1.0",

--- a/examples/apollo/src/index.ts
+++ b/examples/apollo/src/index.ts
@@ -1,4 +1,4 @@
-import { expressMiddleware } from '@apollo/server/express4';
+import { expressMiddleware } from '@as-integrations/express4';
 import { json } from 'body-parser';
 
 import { app, httpServer, server } from './server';

--- a/yarn.lock
+++ b/yarn.lock
@@ -658,6 +658,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@as-integrations/express4@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@as-integrations/express4@npm:1.1.2"
+  peerDependencies:
+    "@apollo/server": ^4.0.0 || ^5.0.0
+    express: ^4.0.0
+  checksum: 10/e7026e5f360f1cc8b85f270660c43253d0b382206698945673479b2a640997a9b10ab4f40068cb9f4628d5f1893a4ae90fe8e5a34c065832f31a6ec3aa85fbe8
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.18.6, @babel/code-frame@npm:^7.5.5":
   version: 7.18.6
   resolution: "@babel/code-frame@npm:7.18.6"
@@ -12054,6 +12064,7 @@ __metadata:
   dependencies:
     "@apollo/gateway": "npm:2.11.0"
     "@apollo/server": "npm:^5.2.0"
+    "@as-integrations/express4": "npm:^1.1.2"
     "@escape.tech/graphql-armor": "npm:*"
     "@types/body-parser": "npm:^1.19.6"
     "@types/express": "npm:5.0.3"


### PR DESCRIPTION
Fix deps for apollo exemple.

As mentioned in https://github.com/Escape-Technologies/graphql-armor/pull/818 
> Express integration requires a separate package. In Apollo Server 4, you could import the Express 4 middleware from @apollo/server/express4, or you could import it from the separate package @as-integrations/express4. In Apollo Server 5, you must import it from the separate package. You can migrate your server to the new package before upgrading to Apollo Server 5. (You can also use @as-integrations/express5 for a middleware that works with Express 5.)

Thank you for your work!

Trob'